### PR TITLE
update repo; fix analysis issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 packages
 pubspec.lock
 .project
+.pub/
 .buildlog
-
+.settings/

--- a/lib/pageloader.dart
+++ b/lib/pageloader.dart
@@ -3,8 +3,6 @@ library pageloader;
 import 'dart:async';
 import 'dart:mirrors';
 
-import 'package:meta/meta.dart';
-
 import 'webdriver.dart';
 
 part 'src/pageloader/annotations.dart';

--- a/lib/src/command_processor.dart
+++ b/lib/src/command_processor.dart
@@ -18,9 +18,6 @@ class CommandProcessor {
   }
 
   void _failRequest(Completer completer, error, [stackTrace]) {
-    if (stackTrace == null) {
-      stackTrace = getAttachedStackTrace(error);
-    }
     completer
         .completeError(new WebDriverError(-1, error.toString()), stackTrace);
   }
@@ -110,7 +107,7 @@ class CommandProcessor {
                 completer.complete(value);
               }
             });
-      }).catchError((error) => _failRequest(completer, error));
+      }).catchError((error, s) => _failRequest(completer, error, s));
     } catch (e, s) {
       _failRequest(completer, e, s);
     }

--- a/lib/src/keyboard.dart
+++ b/lib/src/keyboard.dart
@@ -37,4 +37,7 @@ class Keyboard extends _WebDriverBase implements Future {
 
   Future whenComplete(action()) =>
       _future.whenComplete(action);
+
+  Future timeout(Duration timeLimit, {onTimeout()}) =>
+      _future.timeout(timeLimit, onTimeout: onTimeout);
 }

--- a/lib/src/mouse.dart
+++ b/lib/src/mouse.dart
@@ -94,4 +94,7 @@ class Mouse extends _WebDriverBase implements Future {
 
   Future whenComplete(action()) =>
       _future.whenComplete(action);
+
+  Future timeout(Duration timeLimit, {onTimeout()}) =>
+      _future.timeout(timeLimit, onTimeout: onTimeout);
 }

--- a/lib/src/pageloader/core.dart
+++ b/lib/src/pageloader/core.dart
@@ -29,7 +29,9 @@ class PageLoader {
   InstanceMirror _reflectedInstance(ClassMirror aClass) {
     InstanceMirror page;
 
-    for (MethodMirror constructor in aClass.constructors.values) {
+    Iterable<MethodMirror> ctors = aClass.instanceMembers.values.where(
+        (member) => member.isConstructor);
+    for (MethodMirror constructor in ctors) {
       if (constructor.parameters.isEmpty) {
         page = aClass.newInstance(constructor.constructorName, []);
         break;

--- a/lib/src/touch.dart
+++ b/lib/src/touch.dart
@@ -95,4 +95,7 @@ class Touch extends _WebDriverBase implements Future {
 
   Future whenComplete(action()) =>
       _future.whenComplete(action);
+
+  Future timeout(Duration timeLimit, {onTimeout()}) =>
+      _future.timeout(timeLimit, onTimeout: onTimeout);
 }

--- a/lib/webdriver.dart
+++ b/lib/webdriver.dart
@@ -7,8 +7,8 @@ library webdriver;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io' hide JSON;
+
 import 'package:crypto/crypto.dart';
-import 'package:meta/meta.dart';
 
 part 'src/alert.dart';
 part 'src/capabilities.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,12 @@
 name: webdriver
 version: 0.8.7
 author: Dart Team <misc@dartlang.org>
-description: Provides WebDriver bindings for Dart. These use the WebDriver JSON interface, and as such, require the use of the WebDriver remote server.
-homepage: https://github.com/dart-lang/webdriver
+description: >
+  Provides WebDriver bindings for Dart. These use the WebDriver JSON interface,
+  and as such, require the use of the WebDriver remote server.
+homepage: https://github.com/google/webdriver.dart
 environment:
-  sdk: '>=0.8.7'
+  sdk: '>=1.0.0 <2.0.0'
 dependencies:
   crypto: '>=0.8.7'
 dev_dependencies:

--- a/test/src/web_driver_test.dart
+++ b/test/src/web_driver_test.dart
@@ -88,10 +88,9 @@ void main() {
       });
 
       test('findElement -- success', () {
-        driver.findElement(new By.tagName('tr'))
-            .then(expectAsync1((element) {
-              expect(element, isWebElement);
-            }));
+        return driver.findElement(new By.tagName('tr')) .then((element) {
+          expect(element, isWebElement);
+        });
       });
 
       test('findElement -- failure', () {


### PR DESCRIPTION
Update the package to deal with SDK version changes.

- `expectAsync1` no longer exists
- package:meta/meta.dart no longer used
- getAttachedStackTrace no longer exists
- `Future` added `timeout`