### PR TITLE
run tests on travis using chromedriver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,20 @@
 language: dart
+
 dart: dev
+
+before_install:
+  - export CHROMEDRIVER_BINARY=/usr/bin/chromium-browser
+  - export CHROMEDRIVER_ARGS=--no-sandbox
+  - /usr/bin/chromium-browser --version
+
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
+before_script:
+# We use a slightly older version of chromedriver; the newer ones require a later
+# version of chromium than is available on travis by default.
+  - wget http://chromedriver.storage.googleapis.com/2.12/chromedriver_linux64.zip
+  - unzip chromedriver_linux64.zip
+  - sudo mv chromedriver /usr/bin/
+
 script: ./tool/travis.sh

--- a/test/src/alert_test.dart
+++ b/test/src/alert_test.dart
@@ -2,6 +2,7 @@ library webdriver_test.alert;
 
 import 'package:unittest/unittest.dart';
 import 'package:webdriver/webdriver.dart';
+
 import '../test_util.dart';
 
 void main() {
@@ -11,8 +12,7 @@ void main() {
     WebElement output;
 
     setUp(() async {
-      driver = await WebDriver.createDriver(
-          desiredCapabilities: Capabilities.chrome);
+      driver = await createTestDriver();
       await driver.get(testPagePath);
       button = await driver.findElement(const By.tagName('button'));
       output = await driver.findElement(const By.id('settable'));

--- a/test/src/keyboard_test.dart
+++ b/test/src/keyboard_test.dart
@@ -2,6 +2,7 @@ library webdriver_test.keyboard;
 
 import 'package:unittest/unittest.dart';
 import 'package:webdriver/webdriver.dart';
+
 import '../test_util.dart';
 
 void main() {
@@ -10,8 +11,7 @@ void main() {
     WebElement textInput;
 
     setUp(() async {
-      driver = await WebDriver.createDriver(
-          desiredCapabilities: Capabilities.firefox);
+      driver = await createTestDriver();
       await driver.get(testPagePath);
       textInput =
           await driver.findElement(const By.cssSelector('input[type=text]'));

--- a/test/src/logs_test.dart
+++ b/test/src/logs_test.dart
@@ -3,14 +3,18 @@ library webdriver_test.logs;
 import 'package:unittest/unittest.dart';
 import 'package:webdriver/webdriver.dart';
 
+import '../test_util.dart';
+
 void main() {
   group('Logs', () {
     WebDriver driver;
 
     setUp(() async {
-      Map capabilities = Capabilities.chrome
-        ..[Capabilities.LOGGING_PREFS] = {LogType.PERFORMANCE: LogLevel.INFO};
-      driver = await WebDriver.createDriver(desiredCapabilities: capabilities);
+      Map capabilities = {
+        Capabilities.LOGGING_PREFS: {LogType.PERFORMANCE: LogLevel.INFO}
+      };
+
+      driver = await createTestDriver(additionalCapabilities: capabilities);
       await driver.get('http://www.google.com');
     });
 

--- a/test/src/mouse_test.dart
+++ b/test/src/mouse_test.dart
@@ -2,6 +2,7 @@ library webdriver_test.mouse;
 
 import 'package:unittest/unittest.dart';
 import 'package:webdriver/webdriver.dart';
+
 import '../test_util.dart';
 
 void main() {
@@ -10,8 +11,7 @@ void main() {
     WebElement button;
 
     setUp(() async {
-      driver = await WebDriver.createDriver(
-          desiredCapabilities: Capabilities.chrome);
+      driver = await createTestDriver();
       await driver.get(testPagePath);
       button = await driver.findElement(const By.tagName('button'));
     });

--- a/test/src/navigation_test.dart
+++ b/test/src/navigation_test.dart
@@ -3,13 +3,14 @@ library webdriver_test.navigation;
 import 'package:unittest/unittest.dart';
 import 'package:webdriver/webdriver.dart';
 
+import '../test_util.dart';
+
 void main() {
   group('Navigation', () {
     WebDriver driver;
 
     setUp(() async {
-      driver = await WebDriver.createDriver(
-          desiredCapabilities: Capabilities.chrome);
+      driver = await createTestDriver();
       await driver.get('http://www.google.com/ncr');
     });
 

--- a/test/src/options_test.dart
+++ b/test/src/options_test.dart
@@ -3,13 +3,14 @@ library webdriver_test.options;
 import 'package:unittest/unittest.dart';
 import 'package:webdriver/webdriver.dart';
 
+import '../test_util.dart';
+
 void main() {
   group('Cookies', () {
     WebDriver driver;
 
     setUp(() async {
-      driver = await WebDriver.createDriver(
-          desiredCapabilities: Capabilities.chrome);
+      driver = await createTestDriver();
       await driver.get('http://www.google.com');
     });
 
@@ -68,8 +69,7 @@ void main() {
     WebDriver driver;
 
     setUp(() async {
-      driver = await WebDriver.createDriver(
-          desiredCapabilities: Capabilities.chrome);
+      driver = await createTestDriver();
     });
 
     tearDown(() => driver.quit());

--- a/test/src/target_locator_test.dart
+++ b/test/src/target_locator_test.dart
@@ -2,6 +2,7 @@ library webdriver_test.target_locator;
 
 import 'package:unittest/unittest.dart';
 import 'package:webdriver/webdriver.dart';
+
 import '../test_util.dart';
 
 /**
@@ -14,8 +15,7 @@ void main() {
     WebElement frame;
 
     setUp(() async {
-      driver = await WebDriver.createDriver(
-          desiredCapabilities: Capabilities.chrome);
+      driver = await createTestDriver();
       await driver.get(testPagePath);
       frame = await driver.findElement(new By.name('frame'));
     });

--- a/test/src/web_driver_test.dart
+++ b/test/src/web_driver_test.dart
@@ -2,13 +2,14 @@ library webdriver_test.web_driver;
 
 import 'package:unittest/unittest.dart';
 import 'package:webdriver/webdriver.dart';
+
 import '../test_util.dart';
 
 void main() {
   group('WebDriver', () {
     group('create', () {
       test('default', () async {
-        WebDriver driver = await WebDriver.createDriver();
+        WebDriver driver = await createTestDriver();
         await driver.get('http://www.google.com');
         var element = await driver.findElement(new By.name('q'));
         expect(await element.name, 'input');
@@ -16,8 +17,7 @@ void main() {
       });
 
       test('chrome', () async {
-        WebDriver driver = await WebDriver.createDriver(
-            desiredCapabilities: Capabilities.chrome);
+        WebDriver driver = await createTestDriver();
         await driver.get('http://www.google.com');
         var element = await driver.findElement(new By.name('q'));
         expect(await element.name, 'input');
@@ -25,6 +25,9 @@ void main() {
       });
 
       test('firefox', () async {
+        // Avoid this test on the bot; currently we just test against chromedriver.
+        if (isRunningOnTravis()) return;
+
         WebDriver driver = await WebDriver.createDriver(
             desiredCapabilities: Capabilities.firefox);
         await driver.get('http://www.google.com');
@@ -38,8 +41,7 @@ void main() {
       WebDriver driver;
 
       setUp(() async {
-        driver = await WebDriver.createDriver(
-            desiredCapabilities: Capabilities.chrome);
+        driver = await createTestDriver();
         await driver.get(testPagePath);
       });
 

--- a/test/src/web_element_test.dart
+++ b/test/src/web_element_test.dart
@@ -2,6 +2,7 @@ library webdriver_test.web_element;
 
 import 'package:unittest/unittest.dart';
 import 'package:webdriver/webdriver.dart';
+
 import '../test_util.dart';
 
 void main() {
@@ -16,8 +17,7 @@ void main() {
     WebElement invisible;
 
     setUp(() async {
-      driver = await WebDriver.createDriver(
-          desiredCapabilities: Capabilities.chrome);
+      driver = await createTestDriver();
       await driver.get(testPagePath);
       table = await driver.findElement(new By.tagName('table'));
       button = await driver.findElement(new By.tagName('button'));

--- a/test/src/window_test.dart
+++ b/test/src/window_test.dart
@@ -3,13 +3,14 @@ library webdriver_test.window;
 import 'package:unittest/unittest.dart';
 import 'package:webdriver/webdriver.dart';
 
+import '../test_util.dart';
+
 void main() {
   group('Window', () {
     WebDriver driver;
 
     setUp(() async {
-      driver = await WebDriver.createDriver(
-          desiredCapabilities: Capabilities.chrome);
+      driver = await createTestDriver();
     });
 
     tearDown(() => driver.quit());

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -1,6 +1,8 @@
 library webdriver_test_util;
 
-import 'dart:io';
+import 'dart:async';
+import 'dart:io' hide Platorm;
+import 'dart:io' as io show Platform;
 
 import 'package:path/path.dart' as path;
 import 'package:unittest/unittest.dart';
@@ -10,6 +12,8 @@ final Matcher isWebDriverError = new isInstanceOf<WebDriverError>();
 final Matcher isWebElement = new isInstanceOf<WebElement>();
 final Matcher isSize = new isInstanceOf<Size>();
 final Matcher isPoint = new isInstanceOf<Point>();
+
+bool isRunningOnTravis() => io.Platform.environment['TRAVIS'] == 'true';
 
 String get testPagePath {
   if (_testPagePath == null) {
@@ -29,3 +33,28 @@ String _getTestPagePath() {
 }
 
 String _testPagePath;
+
+Future<WebDriver> createTestDriver({Map additionalCapabilities}) {
+  Map capabilities = Capabilities.chrome;
+  Map env = io.Platform.environment;
+
+  Map chromeOptions = {};
+
+  if (env['CHROMEDRIVER_BINARY'] != null) {
+    chromeOptions['binary'] = env['CHROMEDRIVER_BINARY'];
+  }
+
+  if (env['CHROMEDRIVER_ARGS'] != null) {
+    chromeOptions['args'] = env['CHROMEDRIVER_ARGS'].split(' ');
+  }
+
+  if (chromeOptions.isNotEmpty) {
+    capabilities['chromeOptions'] = chromeOptions;
+  }
+
+  if (additionalCapabilities != null) {
+    capabilities.addAll(additionalCapabilities);
+  }
+
+  return WebDriver.createDriver(desiredCapabilities: capabilities);
+}

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -12,4 +12,10 @@ dartanalyzer --fatal-warnings \
   lib/webdriver.dart \
   test/webdriver_test.dart
 
-# TODO: Setup chromedriver / selenium and run test/webdriver_test.dart.
+if [ "$TRAVIS" ]; then
+  # Start chromedriver.
+  chromedriver --port=4444 --url-base=wd/hub &
+  
+  # Run test/webdriver_test.dart.
+  dart test/webdriver_test.dart
+fi


### PR DESCRIPTION
(redux of an earlier PR)

- set up a xvfb on travis
- have a common `createTestDriver()` method
- install `chromedriver` on travis
- set up args to start chromium instead of chrome (`/usr/bin/chromium-browser`) - travis comes with chromium available. Also, start chromium with the `--no-sandbox` cli arg - otherwise chrome won't start up under travis' virtualization
- use a slightly older version of chromedriver, so it can talk to chromium 37 (what travis has installed by default).

@DrMarcII 

