### PR TITLE
Improved closing behavior, add support for connecting to existing sessions.

### DIFF
--- a/lib/html.dart
+++ b/lib/html.dart
@@ -32,6 +32,16 @@ Future<WebDriver> createDriver({Uri uri, Map<String, dynamic> desired}) async {
       new UnmodifiableMapView(response['value']));
 }
 
+Future<WebDriver> fromExistingSession(String sessionId, {Uri uri}) async {
+  if (uri == null) {
+    uri = defaultUri;
+  }
+
+  var commandProcessor = new _HtmlCommandProcessor();
+
+  return new WebDriver(commandProcessor, uri, sessionId, const {});
+}
+
 class _HtmlCommandProcessor implements CommandProcessor {
   Lock _lock = new Lock();
 
@@ -43,6 +53,8 @@ class _HtmlCommandProcessor implements CommandProcessor {
 
   Future<Object> delete(Uri uri, {bool value: true}) =>
       _request('DELETE', uri, null, value);
+
+  Future close() async {}
 
   Future<Object> _request(
       String method, Uri uri, dynamic params, bool value) async {

--- a/lib/io.dart
+++ b/lib/io.dart
@@ -38,6 +38,16 @@ Future<WebDriver> createDriver({Uri uri, Map<String, dynamic> desired}) async {
       new UnmodifiableMapView(response['value']));
 }
 
+Future<WebDriver> fromExistingSession(String sessionId, {Uri uri}) async {
+  if (uri == null) {
+    uri = defaultUri;
+  }
+
+  var commandProcessor = new _IOCommandProcessor();
+
+  return new WebDriver(commandProcessor, uri, sessionId, const {});
+}
+
 final ContentType _contentTypeJson =
     new ContentType("application", "json", charset: "utf-8");
 
@@ -73,6 +83,10 @@ class _IOCommandProcessor implements CommandProcessor {
     HttpClientRequest request = await client.deleteUrl(uri);
     _setUpRequest(request);
     return await _processResponse(await request.close(), value);
+  }
+
+  Future close() async {
+    await client.close(force: true);
   }
 
   _processResponse(HttpClientResponse response, bool value) async {

--- a/lib/src/command_processor.dart
+++ b/lib/src/command_processor.dart
@@ -9,4 +9,6 @@ abstract class CommandProcessor {
   Future<Object> get(Uri uri, {bool value: true});
 
   Future<Object> delete(Uri uri, {bool value: true});
+
+  Future close();
 }

--- a/lib/src/web_driver.dart
+++ b/lib/src/web_driver.dart
@@ -63,6 +63,7 @@ class WebDriver implements SearchContext {
   /// Quit the browser.
   Future quit() async {
     await _commandProcessor.delete(uri.resolve('session/$id'));
+    await _commandProcessor.close();
   }
 
   /// Handles for all of the currently displayed tabs/windows.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdriver
-version: 0.10.0-pre.1
+version: 0.10.0-pre.2
 author: Google Inc.
 description: >
   Provides WebDriver bindings for Dart. These use the WebDriver JSON interface,


### PR DESCRIPTION
Added close() method to CommandProcessor that gets called by WebDriver.quit()
Ensure that HttpClient in _IOCommandProcessor gets called.
Add fromExistingSession() functions to allow creation of WebDriver instances connected to existing sessions.
Incremented prerelease version number.