### PR TITLE
Rename get, post, and delete methods on WebDriver.

### DIFF
--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -43,11 +43,11 @@ abstract class _WebDriverBase {
   _WebDriverBase(this.driver, this._prefix);
 
   Future _post(String command, [param]) =>
-      driver.post(_resolve(command), param);
+      driver.postRequest(_resolve(command), param);
 
-  Future _get(String command) => driver.get(_resolve(command));
+  Future _get(String command) => driver.getRequest(_resolve(command));
 
-  Future _delete(String command) => driver.delete(_resolve(command));
+  Future _delete(String command) => driver.deleteRequest(_resolve(command));
 
   String _resolve(command) {
     if (_prefix == null || _prefix.isEmpty) {

--- a/lib/src/navigation.dart
+++ b/lib/src/navigation.dart
@@ -17,13 +17,6 @@ part of webdriver.core;
 class Navigation extends _WebDriverBase {
   Navigation._(driver) : super(driver, '');
 
-  Future to(/* Uri | String */ url) async {
-    if (url is Uri) {
-      url = url.toString();
-    }
-    await _post('url', {'url': url});
-  }
-
   ///  Navigate forwards in the browser history, if possible.
   Future forward() async {
     await _post('forward');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdriver
-version: 0.10.0-pre.2
+version: 0.10.0-pre.3
 author: Google, Inc.
 description: >
   Provides WebDriver bindings for Dart. These use the WebDriver JSON interface,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webdriver
 version: 0.10.0-pre.2
-author: Google Inc.
+author: Google, Inc.
 description: >
   Provides WebDriver bindings for Dart. These use the WebDriver JSON interface,
   and as such, require the use of the WebDriver remote server.

--- a/test/src/alert_test.dart
+++ b/test/src/alert_test.dart
@@ -27,7 +27,7 @@ void main() {
 
     setUp(() async {
       driver = await createTestDriver();
-      await driver.navigate.to(testPagePath);
+      await driver.get(testPagePath);
       button = await driver.findElement(const By.tagName('button'));
       output = await driver.findElement(const By.id('settable'));
     });

--- a/test/src/keyboard_test.dart
+++ b/test/src/keyboard_test.dart
@@ -26,7 +26,7 @@ void main() {
 
     setUp(() async {
       driver = await createTestDriver();
-      await driver.navigate.to(testPagePath);
+      await driver.get(testPagePath);
       textInput =
           await driver.findElement(const By.cssSelector('input[type=text]'));
       await textInput.click();

--- a/test/src/logs_test.dart
+++ b/test/src/logs_test.dart
@@ -29,7 +29,7 @@ void main() {
       };
 
       driver = await createTestDriver(additionalCapabilities: capabilities);
-      await driver.navigate.to('http://www.google.com');
+      await driver.get('http://www.google.com');
     });
 
     tearDown(() => driver.quit());

--- a/test/src/mouse_test.dart
+++ b/test/src/mouse_test.dart
@@ -26,7 +26,7 @@ void main() {
 
     setUp(() async {
       driver = await createTestDriver();
-      await driver.navigate.to(testPagePath);
+      await driver.get(testPagePath);
       button = await driver.findElement(const By.tagName('button'));
     });
 

--- a/test/src/navigation_test.dart
+++ b/test/src/navigation_test.dart
@@ -26,13 +26,13 @@ void main() {
 
     setUp(() async {
       driver = await createTestDriver();
-      await driver.navigate.to('http://www.google.com/ncr');
+      await driver.get('http://www.google.com/ncr');
     });
 
     tearDown(() => driver.quit());
 
     test('forward/back', () async {
-      await driver.navigate.to('http://www.yahoo.com');
+      await driver.get('http://www.yahoo.com');
       await driver.navigate.back();
       await waitFor(() => driver.title, matcher: contains('Google'));
       await driver.navigate.forward();

--- a/test/src/options_test.dart
+++ b/test/src/options_test.dart
@@ -25,7 +25,7 @@ void main() {
 
     setUp(() async {
       driver = await createTestDriver();
-      await driver.navigate.to('http://www.google.com');
+      await driver.get('http://www.google.com');
     });
 
     tearDown(() => driver.quit());

--- a/test/src/target_locator_test.dart
+++ b/test/src/target_locator_test.dart
@@ -30,7 +30,7 @@ void main() {
 
     setUp(() async {
       driver = await createTestDriver();
-      await driver.navigate.to(testPagePath);
+      await driver.get(testPagePath);
       frame = await driver.findElement(new By.name('frame'));
     });
 

--- a/test/src/web_driver_test.dart
+++ b/test/src/web_driver_test.dart
@@ -24,7 +24,7 @@ void main() {
     group('create', () {
       test('default', () async {
         WebDriver driver = await createTestDriver();
-        await driver.navigate.to('http://www.google.com');
+        await driver.get('http://www.google.com');
         var element = await driver.findElement(new By.name('q'));
         expect(await element.name, 'input');
         await driver.quit();
@@ -32,7 +32,7 @@ void main() {
 
       test('chrome', () async {
         WebDriver driver = await createTestDriver();
-        await driver.navigate.to('http://www.google.com');
+        await driver.get('http://www.google.com');
         var element = await driver.findElement(new By.name('q'));
         expect(await element.name, 'input');
         await driver.quit();
@@ -44,7 +44,7 @@ void main() {
 
         WebDriver driver = await createTestDriver(
             additionalCapabilities: Capabilities.firefox);
-        await driver.navigate.to('http://www.google.com');
+        await driver.get('http://www.google.com');
         var element = await driver.findElement(new By.name('q'));
         expect(await element.name, 'input');
         await driver.quit();
@@ -56,15 +56,15 @@ void main() {
 
       setUp(() async {
         driver = await createTestDriver();
-        await driver.navigate.to(testPagePath);
+        await driver.get(testPagePath);
       });
 
       tearDown(() => driver.quit());
 
       test('get', () async {
-        await driver.navigate.to('http://www.google.com');
+        await driver.get('http://www.google.com');
         await driver.findElement(new By.name('q'));
-        await driver.navigate.to('http://www.yahoo.com');
+        await driver.get('http://www.yahoo.com');
         await driver.findElement(new By.name('p'));
       });
 
@@ -72,7 +72,7 @@ void main() {
         var url = await driver.currentUrl;
         expect(url, anyOf(startsWith('file:'), startsWith('http:')));
         expect(url, endsWith('test_page.html'));
-        await driver.navigate.to('http://www.google.com');
+        await driver.get('http://www.google.com');
         url = await driver.currentUrl;
         expect(url, contains('www.google.com'));
       });

--- a/test/src/web_element_test.dart
+++ b/test/src/web_element_test.dart
@@ -32,7 +32,7 @@ void main() {
 
     setUp(() async {
       driver = await createTestDriver();
-      await driver.navigate.to(testPagePath);
+      await driver.get(testPagePath);
       table = await driver.findElement(new By.tagName('table'));
       button = await driver.findElement(new By.tagName('button'));
       form = await driver.findElement(new By.tagName('form'));


### PR DESCRIPTION
Add new get method to WebDriver for navigation.

Delete navigate.to() method.

Fixes #57 