### PR TITLE
add chords support to keyboard.dart + test

### DIFF
--- a/lib/src/keyboard.dart
+++ b/lib/src/keyboard.dart
@@ -74,6 +74,22 @@ class Keyboard extends _WebDriverBase {
 
   Keyboard._(driver) : super(driver, '');
 
+  /// Simulate pressing many keys at once as a 'chord'.
+  Future sendChord(Iterable<String> chordToSend) async {
+    await sendKeys(createChord(chordToSend));
+  }
+
+  /// Creates a string representation of a chord suitable for use in WebDriver.
+  String createChord(Iterable<String> chord) {
+    StringBuffer chordString = new StringBuffer();
+    for (String s in chord) {
+      chordString.write(s);
+    }
+    chordString.write(nullChar);
+
+    return chordString.toString();
+  }
+
   /// Send [keysToSend] to the active element.
   Future sendKeys(String keysToSend) async {
     await _post('keys', {

--- a/test/src/keyboard.dart
+++ b/test/src/keyboard.dart
@@ -36,7 +36,7 @@ void runTests() {
 
       // Note: Firefox used as Chrome + Mac OSX prevents use of control/meta
       // in chords.
-      // https://code.google.com/p/selenium/issues/detail?id=5919
+      // https://bugs.chromium.org/p/chromedriver/issues/detail?id=30
       driver = await createTestDriver(
           additionalCapabilities: Capabilities.firefox);
       await driver.get(testPagePath);


### PR DESCRIPTION
Adds basic, explicit support for chords to keyboard.dart.