### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdriver
-version: 0.10.0-pre.15
+version: 1.0.0
 author: Marc Fisher II <fisherii@google.com>
 description: >
   Provides WebDriver bindings for Dart. These use the WebDriver JSON interface,


### PR DESCRIPTION
There has been some unhappiness about how we use version numbers for this package. My suggestion is: The next release should be version 1.0.0 and we then use semantic versioning (http://semver.org/) going forward.