### PR TITLE
Remove package:crypto dependency

### DIFF
--- a/lib/core.dart
+++ b/lib/core.dart
@@ -16,9 +16,9 @@ library webdriver.core;
 
 import 'dart:async' show Future, Stream, StreamController;
 import 'dart:collection' show UnmodifiableMapView;
+import 'dart:convert' show BASE64;
 import 'dart:math' show Point, Rectangle;
 
-import 'package:crypto/crypto.dart' show CryptoUtils;
 import 'package:stack_trace/stack_trace.dart' show Chain;
 
 import 'src/command_processor.dart' show CommandProcessor;

--- a/lib/src/web_driver.dart
+++ b/lib/src/web_driver.dart
@@ -143,7 +143,7 @@ class WebDriver implements SearchContext {
   /// Take a screenshot of the current page as PNG.
   Stream<int> captureScreenshot() async* {
     var encoded = await getRequest('screenshot');
-    yield* new Stream.fromIterable(CryptoUtils.base64StringToBytes(encoded));
+    yield* new Stream.fromIterable(BASE64.decode(encoded));
   }
 
   /// Inject a snippet of JavaScript into the page for execution in the context

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdriver
-version: 1.0.0
+version: 1.0.1
 author: Marc Fisher II <fisherii@google.com>
 description: >
   Provides WebDriver bindings for Dart. These use the WebDriver JSON interface,
@@ -8,7 +8,6 @@ homepage: https://github.com/google/webdriver.dart
 environment:
   sdk: '>=1.10.0 <2.0.0'
 dependencies:
-  crypto: '^0.9.0'
   matcher: '^0.12.0+1'
   path: '^1.3.6'
   stack_trace: '^1.3.4'


### PR DESCRIPTION
The crypto package has been updated and this may cause version incompatibility. 
The good news is that this dependency is not needed.