### PR TITLE
Update forwarder and fix other warnings throughout the library

### DIFF
--- a/lib/html.dart
+++ b/lib/html.dart
@@ -15,7 +15,7 @@
 library webdriver.html;
 
 import 'dart:async' show Future;
-import 'dart:convert' show JSON, UTF8;
+import 'dart:convert' show JSON;
 import 'dart:html' show HttpRequest, ProgressEvent;
 
 import 'package:webdriver/support/async.dart' show Lock;

--- a/lib/support/forwarder.dart
+++ b/lib/support/forwarder.dart
@@ -14,13 +14,13 @@
 
 library webdriver.support.forwarder;
 
-import 'dart:async' show Future, StreamConsumer;
+import 'dart:async' show Future;
 import 'dart:convert' show JSON, UTF8;
 import 'dart:io' show ContentType, Directory, File, HttpRequest, HttpStatus;
 
 import 'package:path/path.dart' as path;
 import 'package:webdriver/core.dart'
-    show By, WebDriver, WebDriverException, WebElement;
+    show By, WebDriver, WebDriverException;
 
 final _contentTypeJson =
     new ContentType('application', 'json', charset: 'utf-8');
@@ -133,8 +133,8 @@ class WebDriverForwarder {
         if (method == 'POST') {
           // take a screenshot and save to file system
           var file =
-              new File(path.join(outputDir.path, params['file'])).openWrite();
-          await driver.captureScreenshot().map((b) => [b]).pipe(file);
+              new File(path.join(outputDir.path, params['file']));
+          await file.writeAsBytes(await driver.captureScreenshotAsList());
           return null;
         }
         break;

--- a/test/io_config.dart
+++ b/test/io_config.dart
@@ -17,7 +17,7 @@ library webdriver.io_test;
 import 'dart:io' show FileSystemEntity, Platform;
 
 import 'package:path/path.dart' as path;
-import 'package:webdriver/io.dart' show WebDriver, Capabilities, createDriver;
+import 'package:webdriver/io.dart' show Capabilities, createDriver;
 
 import 'test_util.dart' as test_util;
 


### PR DESCRIPTION
This fixes #116 

This should also speed up screenshot requests that pass through the forwarder. It was implemented in a very inefficient way before... :-/

Tested: with pub run test.