### PR TITLE
_performRequest now uses whenComplete, not finally. 

### DIFF
--- a/lib/src/web_driver.dart
+++ b/lib/src/web_driver.dart
@@ -232,6 +232,8 @@ class WebDriver implements SearchContext {
       command,
       null);
 
+  // Performs request and sends the result to listeners/onCommandController.
+  // This is typically always what you want to use.
   Future _performRequestWithLog(
       Function fn, String method, String command, params) async {
     return await _performRequest(fn, method, command, params)
@@ -251,6 +253,9 @@ class WebDriver implements SearchContext {
   // This is an ugly hack, I know, but I dunno how to cleanly do this.
   var _previousEvent = null;
 
+  // Performs the request. This will not notify any listeners or
+  // onCommandController. This should only be called from
+  // _performRequestWithLog.
   Future _performRequest(
       Function fn, String method, String command, params) async {
     var startTime = new DateTime.now();

--- a/lib/src/web_driver.dart
+++ b/lib/src/web_driver.dart
@@ -217,20 +217,39 @@ class WebDriver implements SearchContext {
     }
   }
 
-  Future postRequest(String command, [params]) => _performRequest(
+  Future postRequest(String command, [params]) => _performRequestWithLog(
       () => _commandProcessor.post(_resolve(command), params),
       'POST',
       command,
       params);
 
-  Future getRequest(String command) => _performRequest(
+  Future getRequest(String command) => _performRequestWithLog(
       () => _commandProcessor.get(_resolve(command)), 'GET', command, null);
 
-  Future deleteRequest(String command) => _performRequest(
+  Future deleteRequest(String command) => _performRequestWithLog(
       () => _commandProcessor.delete(_resolve(command)),
       'DELETE',
       command,
       null);
+
+  Future _performRequestWithLog(
+      Function fn, String method, String command, params) async {
+    return await _performRequest(fn, method, command, params)
+        .whenComplete(() async {
+      if (notifyListeners) {
+        if (_previousEvent == null) {
+          throw new Error(); // This should be impossible.
+        }
+        _onCommandController.add(_previousEvent);
+        for (WebDriverListener listener in _commandListeners) {
+          await listener(_previousEvent);
+        }
+      }
+    });
+  }
+
+  // This is an ugly hack, I know, but I dunno how to cleanly do this.
+  var _previousEvent = null;
 
   Future _performRequest(
       Function fn, String method, String command, params) async {
@@ -256,7 +275,7 @@ class WebDriver implements SearchContext {
       return new Future.error(e, trace);
     } finally {
       if (notifyListeners) {
-        var event = new WebDriverCommandEvent(
+        _previousEvent = new WebDriverCommandEvent(
             method: method,
             endPoint: command,
             params: params,
@@ -265,11 +284,6 @@ class WebDriver implements SearchContext {
             exception: exception,
             result: result,
             stackTrace: trace);
-
-        _onCommandController.add(event);
-        for (WebDriverListener listener in _commandListeners) {
-          await listener(event);
-        }
       }
     }
   }

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -34,15 +34,15 @@ import 'io_config.dart' as config;
 void main() {
   config.config();
 
-  alert.runTests();
+  /*alert.runTests();
   command_event.runTests();
   keyboard.runTests();
   logs.runTests();
   mouse.runTests();
   navigation.runTests();
   options.runTests();
-  target_locator.runTests();
+  target_locator.runTests();*/
   web_driver.runTests();
-  web_element.runTests();
-  window.runTests();
+  /*web_element.runTests();
+  window.runTests();*/
 }

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -34,15 +34,15 @@ import 'io_config.dart' as config;
 void main() {
   config.config();
 
-  /*alert.runTests();
+  alert.runTests();
   command_event.runTests();
   keyboard.runTests();
   logs.runTests();
   mouse.runTests();
   navigation.runTests();
   options.runTests();
-  target_locator.runTests();*/
+  target_locator.runTests();
   web_driver.runTests();
-  /*web_element.runTests();
-  window.runTests();*/
+  web_element.runTests();
+  window.runTests();
 }

--- a/test/src/web_driver.dart
+++ b/test/src/web_driver.dart
@@ -60,7 +60,7 @@ void runTests() {
 
       tearDown(() => driver.quit());
 
-      /*test('get', () async {
+      test('get', () async {
         await driver.get('http://www.google.com/ncr');
         await driver.findElement(const By.name('q'));
         await driver.get('http://www.yahoo.com');
@@ -190,7 +190,7 @@ void runTests() {
         var screenshot = await driver.captureScreenshotAsBase64();
         expect(screenshot, hasLength(isPositive));
         expect(screenshot, new isInstanceOf<String>());
-      });*/
+      });
 
       test('future based event listeners work with script timeouts', () async {
         driver.addEventListener((WebDriverCommandEvent e) async {
@@ -201,14 +201,14 @@ void runTests() {
 
         try {
           driver.timeouts.setScriptTimeout(new Duration(seconds: 1));
-          var e = await driver.executeAsync('', []);
+          await driver.executeAsync('', []);
           fail('Did not throw timeout as expected');
         } catch (e) {
           expect(e.toString(), contains('asynchronous script timeout'));
         }
       });
 
-      test('future based event listeners wait appropriately', () async {
+      test('future based event listeners ordered appropriately', () async {
         var eventList = new List<int>();
         int millisDelay = 2000;
         int current = 0;

--- a/test/src/web_driver.dart
+++ b/test/src/web_driver.dart
@@ -195,8 +195,7 @@ void runTests() {
       test('future based event listeners work with script timeouts', () async {
         driver.addEventListener((WebDriverCommandEvent e) async {
           return await new Future.delayed(
-              new Duration(milliseconds: 1000),
-              (() {}));
+              new Duration(milliseconds: 1000), (() {}));
         });
 
         try {
@@ -213,7 +212,8 @@ void runTests() {
         int millisDelay = 2000;
         int current = 0;
         driver.addEventListener((WebDriverCommandEvent e) async {
-          return await new Future.delayed(new Duration(milliseconds: millisDelay),
+          return await new Future.delayed(
+              new Duration(milliseconds: millisDelay),
               (() {
                 eventList.add(current++);
                 millisDelay = (millisDelay / 2).round();

--- a/test/src/web_driver.dart
+++ b/test/src/web_driver.dart
@@ -60,7 +60,7 @@ void runTests() {
 
       tearDown(() => driver.quit());
 
-      test('get', () async {
+      /*test('get', () async {
         await driver.get('http://www.google.com/ncr');
         await driver.findElement(const By.name('q'));
         await driver.get('http://www.yahoo.com');
@@ -190,6 +190,22 @@ void runTests() {
         var screenshot = await driver.captureScreenshotAsBase64();
         expect(screenshot, hasLength(isPositive));
         expect(screenshot, new isInstanceOf<String>());
+      });*/
+
+      test('future based event listeners work with script timeouts', () async {
+        driver.addEventListener((WebDriverCommandEvent e) async {
+          return await new Future.delayed(
+              new Duration(milliseconds: 1000),
+              (() {}));
+        });
+
+        try {
+          driver.timeouts.setScriptTimeout(new Duration(seconds: 1));
+          var e = await driver.executeAsync('', []);
+          fail('Did not throw timeout as expected');
+        } catch (e) {
+          expect(e.toString(), contains('asynchronous script timeout'));
+        }
       });
 
       test('future based event listeners wait appropriately', () async {

--- a/test/src/web_driver.dart
+++ b/test/src/web_driver.dart
@@ -14,6 +14,8 @@
 
 library webdriver.web_driver_test;
 
+import 'dart:async';
+
 import 'package:test/test.dart';
 import 'package:webdriver/core.dart';
 
@@ -188,6 +190,27 @@ void runTests() {
         var screenshot = await driver.captureScreenshotAsBase64();
         expect(screenshot, hasLength(isPositive));
         expect(screenshot, new isInstanceOf<String>());
+      });
+
+      test('future based event listeners wait appropriately', () async {
+        var eventList = new List<int>();
+        int millisDelay = 2000;
+        int current = 0;
+        driver.addEventListener((WebDriverCommandEvent e) async {
+          return await new Future.delayed(new Duration(milliseconds: millisDelay),
+              (() {
+                eventList.add(current++);
+                millisDelay = (millisDelay / 2).round();
+              }));
+        });
+
+        for (int i = 0; i < 10; i++) {
+          await driver.title; // GET request.
+        }
+        expect(eventList, hasLength(10));
+        for (int i = 0; i < 10; i++) {
+          expect(eventList[i], i);
+        }
       });
     });
   });


### PR DESCRIPTION
_performRequest still uses finally for logging, which is not appropriate when finally produces Futures. This can cause bugs when using Future-base listeners. 

Refactors _performRequest to use whenComplete, and adds tests to verify correctness of Future-based listeners.