### PR TITLE
Enable redirects to handle 303 responses from Selenium

### DIFF
--- a/lib/io.dart
+++ b/lib/io.dart
@@ -116,7 +116,7 @@ class IOCommandProcessor implements CommandProcessor {
   }
 
   void _setUpRequest(HttpClientRequest request) {
-    request.followRedirects = false;
+    request.followRedirects = true;
     request.headers.add(HttpHeaders.ACCEPT, "application/json");
     request.headers.add(HttpHeaders.ACCEPT_CHARSET, UTF8.name);
     request.headers.add(HttpHeaders.CACHE_CONTROL, "no-cache");


### PR DESCRIPTION
Lately, we've been seeing intermittent 303 responses when executing WebDriver commands, which causes errors.

`IOCommandProcessor` should follow those redirects.

Is there a reason these redirects were disabled?