### PR TITLE
Revert "Enable generics for waitFor and require Dart 1.21+ in the pubspec SDK range"

### DIFF
--- a/lib/support/async.dart
+++ b/lib/support/async.dart
@@ -25,11 +25,11 @@ const defaultTimeout = const Duration(seconds: 5);
 
 const clock = const Clock();
 
-Future<T> waitFor<T>(T condition(),
+Future/*<T>*/ waitFor/*<T>*/(/*=T*/ condition(),
         {matcher: null,
         Duration timeout: defaultTimeout,
         Duration interval: defaultInterval}) =>
-    clock.waitFor<T>(condition,
+    clock.waitFor/*<T>*/(condition,
         matcher: matcher, timeout: timeout, interval: interval);
 
 class Clock {
@@ -50,7 +50,7 @@ class Clock {
   /// is returned. Otherwise, if [condition] throws, then that exception is
   /// rethrown. If [condition] doesn't throw then an [expect] exception is
   /// thrown.
-  Future<T> waitFor<T>(T condition(),
+  Future/*<T>*/ waitFor/*<T>*/(/*=T*/ condition(),
       {matcher: null,
       Duration timeout: defaultTimeout,
       Duration interval: defaultInterval}) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >
   and as such, require the use of the WebDriver remote server.
 homepage: https://github.com/google/webdriver.dart
 environment:
-  sdk: '>=1.21.0 <2.0.0'
+  sdk: '>=1.10.0 <2.0.0'
 dependencies:
   archive: '^1.0.0'
   matcher: '^0.12.0'


### PR DESCRIPTION
Reverts google/webdriver.dart#131.. this is breaking downstream consumers for reasons unknown to me.  It should be fixed in the next release of the Dart SDK but in the meantime it's probably best to do another patch release with this reverted :(  Sorry for occupying your time, the issue did not reproduce when consuming this library as a path dependency.