### PR TITLE
Revert "Revert "Enable generics for waitFor and require Dart 1.21+ in the pubspec SDK range""

### DIFF
--- a/lib/support/async.dart
+++ b/lib/support/async.dart
@@ -25,11 +25,11 @@ const defaultTimeout = const Duration(seconds: 5);
 
 const clock = const Clock();
 
-Future/*<T>*/ waitFor/*<T>*/(/*=T*/ condition(),
+Future<T> waitFor<T>(T condition(),
         {matcher: null,
         Duration timeout: defaultTimeout,
         Duration interval: defaultInterval}) =>
-    clock.waitFor/*<T>*/(condition,
+    clock.waitFor<T>(condition,
         matcher: matcher, timeout: timeout, interval: interval);
 
 class Clock {
@@ -50,7 +50,7 @@ class Clock {
   /// is returned. Otherwise, if [condition] throws, then that exception is
   /// rethrown. If [condition] doesn't throw then an [expect] exception is
   /// thrown.
-  Future/*<T>*/ waitFor/*<T>*/(/*=T*/ condition(),
+  Future<T> waitFor<T>(T condition(),
       {matcher: null,
       Duration timeout: defaultTimeout,
       Duration interval: defaultInterval}) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >
   and as such, require the use of the WebDriver remote server.
 homepage: https://github.com/google/webdriver.dart
 environment:
-  sdk: '>=1.10.0 <2.0.0'
+  sdk: '>=1.21.0 <2.0.0'
 dependencies:
   archive: '^1.0.0'
   matcher: '^0.12.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >
   and as such, require the use of the WebDriver remote server.
 homepage: https://github.com/google/webdriver.dart
 environment:
-  sdk: '>=1.21.0 <2.0.0'
+  sdk: '>=1.21.1 <2.0.0'
 dependencies:
   archive: '^1.0.0'
   matcher: '^0.12.0'


### PR DESCRIPTION
@DrMarcII Reverts google/webdriver.dart#135 - the release of Dart 1.21.1 has resolved the issue that the original PR exposed, so we'd like to get this back in and tagged in a new release.  Thanks!