### PR TITLE
Prep for 1.2.3 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## v1.2.2
+## v1.2.3
+
+*  Enable generics for waitFor.
+
+## v1.2.2+1
 
 * Disable generics for waitFor.
 
@@ -6,7 +10,7 @@
 
 *  Refactor tests.
 *  Make project buildable and testable with Bazel.
-*  Enable generics for waitFor.
+
 
 ## v1.2.1
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,9 +16,9 @@ workspace(name = "com_github_google_webdriver_dart")
 
 http_archive(
     name = "io_bazel_rules_dart",
-    sha256 = "45abe3e3fb908f7792bc747b380aa5fdf8f9e66a4f86623ed68acbe1042b1e7e",
-    strip_prefix = "rules_dart-11bca9e70b42470a909782e6369194af38898551",
-    url = "https://github.com/dart-lang/rules_dart/archive/11bca9e70b42470a909782e6369194af38898551.tar.gz",
+    sha256 = "db80bb1dd03485c959424dba8ea1aa4014fa0dbd22d57b069d14e5647f98b04e",
+    strip_prefix = "rules_dart-66d7cd37696b6ee2397e8075da3c6d90812b65ba",
+    url = "https://github.com/dart-lang/rules_dart/archive/66d7cd37696b6ee2397e8075da3c6d90812b65ba.tar.gz",
 )
 
 load("@io_bazel_rules_dart//dart/build_rules:repositories.bzl", "dart_repositories")
@@ -38,11 +38,12 @@ go_repositories()
 
 http_archive(
     name = "io_bazel_rules_webtesting",
-    strip_prefix = "rules_webtesting-f27ab1ce1bf42b3ef0fb4ca15b19507e27c28df9",
-    url = "https://github.com/bazelbuild/rules_webtesting/archive/f27ab1ce1bf42b3ef0fb4ca15b19507e27c28df9.tar.gz",
+    sha256 = "602bd1fd4e2b756baa636c3815ef6686c111b3e30eab534c0fc84e6c8c9a14c3",    
+    strip_prefix = "rules_webtesting-b875457028e38511d76e067378dacc1ffcb6c75b",
+    url = "https://github.com/bazelbuild/rules_webtesting/archive/b875457028e38511d76e067378dacc1ffcb6c75b.tar.gz",
 )
 
-load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories", "browser_repositories")
+load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories")
 
 web_test_repositories()
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdriver
-version: 1.2.2+1
+version: 1.2.3
 author: Marc Fisher II <fisherii@google.com>
 description: >
   Provides WebDriver bindings for Dart. These use the WebDriver JSON interface,

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -65,8 +65,8 @@ def webdriver_dart_repositories(
     native.new_http_archive(
         name="org_dartlang_pub_analyzer",
         build_file=str(Label("//build_files:analyzer.BUILD")),
-        sha256="ee9bb36b3bc588b97d491a28ba5f9823ed1cd0eb99dabdcf5b8b52bf0d757f06",
-        url="https://storage.googleapis.com/pub.dartlang.org/packages/analyzer-0.29.3.tar.gz"
+        sha256="7249fc31827063a154b8d9f4232cf778713cd3cc29074abf19e42d9f0a5572c7",
+        url="https://storage.googleapis.com/pub.dartlang.org/packages/analyzer-0.29.5.tar.gz"
     )
     
   if not omit_org_dartlang_pub_archive:
@@ -89,8 +89,8 @@ def webdriver_dart_repositories(
     native.new_http_archive(
         name="org_dartlang_pub_async",
         build_file=str(Label("//build_files:async.BUILD")),
-        sha256="32f0274fbb1ef81316c7bb6dc33f7b596e25c3dda5b8550163a6f0a89712cdc0",
-        url="https://storage.googleapis.com/pub.dartlang.org/packages/async-1.11.3.tar.gz"
+        sha256="78eda22375d22c73ebfa349d425e8795b375f28a021ee2b14a50827605120213",
+        url="https://storage.googleapis.com/pub.dartlang.org/packages/async-1.12.0.tar.gz"
     )
     
   if not omit_org_dartlang_pub_barback:
@@ -345,8 +345,8 @@ def webdriver_dart_repositories(
     native.new_http_archive(
         name="org_dartlang_pub_stream_channel",
         build_file=str(Label("//build_files:stream_channel.BUILD")),
-        sha256="3cbe42486c5bdb01a366da46bc41903f650018a54825b69ff5ec63a991b8fa72",
-        url="https://storage.googleapis.com/pub.dartlang.org/packages/stream_channel-1.5.0.tar.gz"
+        sha256="e22242ac461247618190a50342c3cd93a2466746637e55201375ccb4654cd420",
+        url="https://storage.googleapis.com/pub.dartlang.org/packages/stream_channel-1.6.0.tar.gz"
     )
 
   if not omit_org_dartlang_pub_string_scanner:


### PR DESCRIPTION
- Update version number in pubspec.
- Update dependency versions in repositories.bzl and WORKSPACE.