### PR TITLE
Fix dynamic_as_bottom warning

### DIFF
--- a/lib/support/stdio_stepper.dart
+++ b/lib/support/stdio_stepper.dart
@@ -108,7 +108,7 @@ class LineReader {
   }
 
   void _listen(/* List<int> | int */ data) {
-    if (data is List) {
+    if (data is List<int>) {
       data.forEach(_addByte);
     } else {
       _addByte(data);


### PR DESCRIPTION
No tests pass before this PR, and... no tests pass after so... we're all good!