### PR TITLE
Add and clean analyzer lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,9 +3,57 @@ analyzer:
 linter:
   rules:
     - always_declare_return_types
-    - empty_constructor_bodies
+    - always_require_non_null_named_parameters
     - annotate_overrides
+    - avoid_empty_else
     - avoid_init_to_null
+    - avoid_null_checks_in_equality_operators
+    - avoid_return_types_on_setters
+    - await_only_futures
+    - cancel_subscriptions
+    - control_flow_in_finally
+    - empty_constructor_bodies
+    - empty_constructor_bodies
+    - empty_statements
+    - hash_and_equals
+    - implementation_imports
+    - iterable_contains_unrelated_type
+    - library_names
+    - library_prefixes
+    - list_remove_unrelated_type
+    - no_adjacent_strings_in_list
+    - no_duplicate_case_values
+    - non_constant_identifier_names
     - one_member_abstracts
+    - overridden_fields
+    - package_api_docs
+    - package_names
+    - package_prefixed_library_names
+    - prefer_asserts_in_initializer_lists
+    - prefer_collection_literals
+    - prefer_conditional_assignment
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    - prefer_contains
+    - prefer_final_fields
+    - prefer_initializing_formals
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_single_quotes
+    - prefer_typing_uninitialized_variables
+    - recursive_getters
     - slash_for_doc_comments
-    - unnecessary_brace_in_string_interp
+    - slash_for_doc_comments
+    - super_goes_last
+    - test_types_in_equals
+    - throw_in_finally
+    - type_init_formals
+    - unawaited_futures
+    - unnecessary_brace_in_string_interps
+    - unnecessary_getters_setters
+    - unnecessary_lambdas
+    - unnecessary_null_aware_assignments
+    - unnecessary_null_in_if_null_operators
+    - unnecessary_overrides
+    - unnecessary_statements
+    - unrelated_type_equality_checks

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,2 +1,11 @@
 analyzer:
   strong-mode: true
+linter:
+  rules:
+    - always_declare_return_types
+    - empty_constructor_bodies
+    - annotate_overrides
+    - avoid_init_to_null
+    - one_member_abstracts
+    - slash_for_doc_comments
+    - unnecessary_brace_in_string_interp

--- a/lib/async_core.dart
+++ b/lib/async_core.dart
@@ -45,13 +45,9 @@ final Uri defaultUri = Uri.parse('http://127.0.0.1:4444/wd/hub/');
 
 Future<WebDriver> createDriver(CommandProcessor processor,
     {Uri uri, Map<String, dynamic> desired}) async {
-  if (uri == null) {
-    uri = defaultUri;
-  }
+  uri ??= defaultUri;
 
-  if (desired == null) {
-    desired = Capabilities.empty;
-  }
+  desired ??= Capabilities.empty;
 
   Map response = await processor.post(
       uri.resolve('session'), {'desiredCapabilities': desired},
@@ -63,9 +59,7 @@ Future<WebDriver> createDriver(CommandProcessor processor,
 Future<WebDriver> fromExistingSession(
     CommandProcessor processor, String sessionId,
     {Uri uri}) async {
-  if (uri == null) {
-    uri = defaultUri;
-  }
+  uri ??= defaultUri;
 
   var response = await processor.get(uri.resolve('session/$sessionId'))
       as Map<String, dynamic>;

--- a/lib/async_io.dart
+++ b/lib/async_io.dart
@@ -94,7 +94,7 @@ class IOCommandProcessor implements CommandProcessor {
     await client.close(force: true);
   }
 
-  _processResponse(HttpClientResponse response, bool value) async {
+  Future<dynamic> _processResponse(HttpClientResponse response, bool value) async {
     var respDecoded = await UTF8.decodeStream(response);
     _lock.release();
     Map respBody;

--- a/lib/async_io.dart
+++ b/lib/async_io.dart
@@ -91,7 +91,7 @@ class IOCommandProcessor implements CommandProcessor {
 
   @override
   Future close() async {
-    await client.close(force: true);
+    client.close(force: true);
   }
 
   Future<dynamic> _processResponse(HttpClientResponse response, bool value) async {

--- a/lib/async_io.dart
+++ b/lib/async_io.dart
@@ -94,7 +94,8 @@ class IOCommandProcessor implements CommandProcessor {
     client.close(force: true);
   }
 
-  Future<dynamic> _processResponse(HttpClientResponse response, bool value) async {
+  Future<dynamic> _processResponse(
+      HttpClientResponse response, bool value) async {
     var respDecoded = await UTF8.decodeStream(response);
     _lock.release();
     Map respBody;

--- a/lib/html.dart
+++ b/lib/html.dart
@@ -67,7 +67,7 @@ class _HtmlCommandProcessor implements CommandProcessor {
   Future<dynamic> _request(
       String method, Uri uri, dynamic params, bool value) async {
     await _lock.acquire();
-    var sendData = null;
+    var sendData;
     if (params != null && method == 'POST') {
       sendData = JSON.encode(params);
     }

--- a/lib/src/async/capabilities.dart
+++ b/lib/src/async/capabilities.dart
@@ -51,7 +51,7 @@ class Capabilities {
     ..[version] = ''
     ..[platform] = BrowserPlatform.android;
 
-  static Map<String, dynamic> get empty => new Map<String, dynamic>();
+  static Map<String, dynamic> get empty => const <String, dynamic>{};
 }
 
 /// Browser name constants.

--- a/lib/src/async/capabilities.dart
+++ b/lib/src/async/capabilities.dart
@@ -36,17 +36,17 @@ class Capabilities {
   static const String loggingPrefs = "loggingPrefs";
   static const String enableProfiling = "webdriver.logging.profiler.enabled";
 
-  static Map<String, dynamic> get chrome => empty
+  static Map<String, dynamic> get chrome => new Map.from(empty)
     ..[browserName] = Browser.chrome
     ..[version] = ''
     ..[platform] = BrowserPlatform.any;
 
-  static Map<String, dynamic> get firefox => empty
+  static Map<String, dynamic> get firefox => new Map.from(empty)
     ..[browserName] = Browser.firefox
     ..[version] = ''
     ..[platform] = BrowserPlatform.any;
 
-  static Map<String, dynamic> get android => empty
+  static Map<String, dynamic> get android => new Map.from(empty)
     ..[browserName] = Browser.android
     ..[version] = ''
     ..[platform] = BrowserPlatform.android;

--- a/lib/src/async/command_event.dart
+++ b/lib/src/async/command_event.dart
@@ -33,6 +33,7 @@ class WebDriverCommandEvent {
       this.result,
       this.stackTrace});
 
+  @override
   String toString() => '[$startTime - $endTime] $method $endPoint($params) => '
       '${exception != null ? exception : result}';
 }

--- a/lib/src/async/common.dart
+++ b/lib/src/async/common.dart
@@ -49,7 +49,7 @@ abstract class _WebDriverBase {
 
   Future _delete(String command) => driver.deleteRequest(_resolve(command));
 
-  String _resolve(command) {
+  String _resolve(String command) {
     if (_prefix == null || _prefix.isEmpty) {
       return command;
     }
@@ -86,10 +86,9 @@ class By {
   /// Returns an element whose tag name matches the search value.
   const By.tagName(String tagName) : this._('tag name', tagName);
 
-  /**
-   * Returns an element whose class name contains the search value; compound
-   * class names are not permitted
-   */
+
+  /// Returns an element whose class name contains the search value; compound
+  /// class names are not permitted
   const By.className(String className) : this._('class name', className);
 
   /// Returns an element matching a CSS selector.

--- a/lib/src/async/common.dart
+++ b/lib/src/async/common.dart
@@ -86,7 +86,6 @@ class By {
   /// Returns an element whose tag name matches the search value.
   const By.tagName(String tagName) : this._('tag name', tagName);
 
-
   /// Returns an element whose class name contains the search value; compound
   /// class names are not permitted
   const By.className(String className) : this._('class name', className);

--- a/lib/src/async/web_driver.dart
+++ b/lib/src/async/web_driver.dart
@@ -31,13 +31,11 @@ class WebDriver implements SearchContext {
   final _onCommandController =
       new StreamController<WebDriverCommandEvent>.broadcast();
 
-  final _commandListeners = new List<WebDriverListener>();
+  final _commandListeners = <WebDriverListener>[];
 
-  WebDriver(this._commandProcessor, Uri uri, String id, this.capabilities,
+  WebDriver(this._commandProcessor, this.uri, this.id, this.capabilities,
       {this.filterStackTraces: true})
-      : this.uri = uri,
-        this.id = id,
-        this._prefix = uri.resolve('session/$id/');
+      : this._prefix = uri.resolve('session/$id/');
 
   /// Deprecated in favor of addEventListener.
   @deprecated
@@ -211,7 +209,7 @@ class WebDriver implements SearchContext {
         return newResult;
       }
     } else if (result is List) {
-      return result.map((value) => _recursiveElementify(value)).toList();
+      return result.map(_recursiveElementify).toList();
     } else {
       return result;
     }

--- a/lib/src/async/web_driver.dart
+++ b/lib/src/async/web_driver.dart
@@ -251,7 +251,7 @@ class WebDriver implements SearchContext {
   }
 
   // This is an ugly hack, I know, but I dunno how to cleanly do this.
-  var _previousEvent = null;
+  var _previousEvent;
 
   // Performs the request. This will not notify any listeners or
   // onCommandController. This should only be called from

--- a/lib/src/async/web_element.dart
+++ b/lib/src/async/web_element.dart
@@ -27,7 +27,7 @@ class WebElement extends _WebDriverBase implements SearchContext {
   /// used to find this element always returns one element, then this is null.
   final int index;
 
-  WebElement(driver, id, [this.context, this.locator, this.index])
+  WebElement(driver, String id, [this.context, this.locator, this.index])
       : this.id = id,
         super(driver, 'element/$id');
 
@@ -84,12 +84,14 @@ class WebElement extends _WebDriverBase implements SearchContext {
   ///Find an element nested within this element.
   ///
   /// Throws [NoSuchElementException] if matching element is not found.
+  @override
   Future<WebElement> findElement(By by) async {
     var element = await _post('element', by);
     return new WebElement(driver, element[_element], this, by);
   }
 
   /// Find multiple elements nested within this element.
+  @override
   Stream<WebElement> findElements(By by) async* {
     var elements = await _post('elements', by);
     int i = 0;

--- a/lib/src/async/web_element.dart
+++ b/lib/src/async/web_element.dart
@@ -27,9 +27,8 @@ class WebElement extends _WebDriverBase implements SearchContext {
   /// used to find this element always returns one element, then this is null.
   final int index;
 
-  WebElement(driver, String id, [this.context, this.locator, this.index])
-      : this.id = id,
-        super(driver, 'element/$id');
+  WebElement(driver, this.id, [this.context, this.locator, this.index])
+      : super(driver, 'element/$id');
 
   /// Click on this element.
   Future click() async {

--- a/lib/src/async/window.dart
+++ b/lib/src/async/window.dart
@@ -17,8 +17,7 @@ part of webdriver.core;
 class Window extends _WebDriverBase {
   final String handle;
 
-  Window._(driver, this.handle)
-      : super(driver, 'window/$handle');
+  Window._(driver, this.handle) : super(driver, 'window/$handle');
 
   /// The size of this window.
   Future<Rectangle<int>> get size async {

--- a/lib/src/async/window.dart
+++ b/lib/src/async/window.dart
@@ -17,9 +17,8 @@ part of webdriver.core;
 class Window extends _WebDriverBase {
   final String handle;
 
-  Window._(driver, handle)
-      : this.handle = handle,
-        super(driver, 'window/$handle');
+  Window._(driver, this.handle)
+      : super(driver, 'window/$handle');
 
   /// The size of this window.
   Future<Rectangle<int>> get size async {

--- a/lib/src/sync/capabilities.dart
+++ b/lib/src/sync/capabilities.dart
@@ -34,17 +34,17 @@ class Capabilities {
   static const String loggingPrefs = "loggingPrefs";
   static const String enableProfiling = "webdriver.logging.profiler.enabled";
 
-  static Map<String, dynamic> get chrome => empty
+  static Map<String, dynamic> get chrome => new Map.from(empty)
     ..[browserName] = Browser.chrome
     ..[version] = ''
     ..[platform] = BrowserPlatform.any;
 
-  static Map<String, dynamic> get firefox => empty
+  static Map<String, dynamic> get firefox => new Map.from(empty)
     ..[browserName] = Browser.firefox
     ..[version] = ''
     ..[platform] = BrowserPlatform.any;
 
-  static Map<String, dynamic> get android => empty
+  static Map<String, dynamic> get android => new Map.from(empty)
     ..[browserName] = Browser.android
     ..[version] = ''
     ..[platform] = BrowserPlatform.android;

--- a/lib/src/sync/capabilities.dart
+++ b/lib/src/sync/capabilities.dart
@@ -49,7 +49,7 @@ class Capabilities {
     ..[version] = ''
     ..[platform] = BrowserPlatform.android;
 
-  static Map<String, dynamic> get empty => new Map<String, dynamic>();
+  static Map<String, dynamic> get empty => const <String, dynamic>{};
 }
 
 /// Browser name constants.

--- a/lib/src/sync/command_event.dart
+++ b/lib/src/sync/command_event.dart
@@ -32,6 +32,7 @@ class WebDriverCommandEvent {
       this.result,
       this.stackTrace});
 
+  @override
   String toString() => '[$startTime - $endTime] $method $endPoint($params) => '
       '${exception != null ? exception : result}';
 }

--- a/lib/src/sync/common.dart
+++ b/lib/src/sync/common.dart
@@ -73,7 +73,7 @@ class Resolver {
 
   dynamic delete(String command) => driver.deleteRequest(_resolve(command));
 
-  String _resolve(command) {
+  String _resolve(String command) {
     if (prefix == null || prefix.isEmpty) {
       return command;
     }
@@ -110,10 +110,9 @@ class By {
   /// Returns an element whose tag name matches the search value.
   const By.tagName(String tagName) : this('tag name', tagName);
 
-  /**
-   * Returns an element whose class name contains the search value; compound
-   * class names are not permitted
-   */
+
+  /// Returns an element whose class name contains the search value; compound
+  /// class names are not permitted
   const By.className(String className) : this('class name', className);
 
   /// Returns an element matching a CSS selector.

--- a/lib/src/sync/common.dart
+++ b/lib/src/sync/common.dart
@@ -110,7 +110,6 @@ class By {
   /// Returns an element whose tag name matches the search value.
   const By.tagName(String tagName) : this('tag name', tagName);
 
-
   /// Returns an element whose class name contains the search value; compound
   /// class names are not permitted
   const By.className(String className) : this('class name', className);

--- a/lib/src/sync/json_wire_spec/navigation.dart
+++ b/lib/src/sync/json_wire_spec/navigation.dart
@@ -24,16 +24,19 @@ class JsonWireNavigation implements Navigation {
   JsonWireNavigation(this._driver) : _resolver = new Resolver(_driver, '');
 
   ///  Navigate forwards in the browser history, if possible.
+  @override
   void forward() {
     _resolver.post('forward');
   }
 
   /// Navigate backwards in the browser history, if possible.
+  @override
   void back() {
     _resolver.post('back');
   }
 
   /// Refresh the current page.
+  @override
   void refresh() {
     _resolver.post('refresh');
   }

--- a/lib/src/sync/json_wire_spec/web_driver.dart
+++ b/lib/src/sync/json_wire_spec/web_driver.dart
@@ -53,14 +53,12 @@ class JsonWireWebDriver implements WebDriver, SearchContext {
   @override
   bool notifyListeners = true;
 
-  final _commandListeners = new List<WebDriverListener>();
+  final _commandListeners = <WebDriverListener>[];
 
   JsonWireWebDriver(
-      this._commandProcessor, Uri uri, String id, this.capabilities,
+      this._commandProcessor, this.uri, this.id, this.capabilities,
       {this.filterStackTraces: true})
-      : this.uri = uri,
-        this.id = id,
-        this._prefix = uri.resolve('session/$id/');
+      : this._prefix = uri.resolve('session/$id/');
 
   @override
   async_core.WebDriver get asyncDriver => createAsyncWebDriver(this);
@@ -89,7 +87,7 @@ class JsonWireWebDriver implements WebDriver, SearchContext {
     final elements = postRequest('elements', byToJson(by));
     int i = 0;
 
-    final webElements = new List<JsonWireWebElement>();
+    final webElements = <JsonWireWebElement>[];
     for (final element in elements) {
       webElements.add(new JsonWireWebElement(
           this, element[jsonWireElementStr], this, by, i++));
@@ -192,7 +190,7 @@ class JsonWireWebDriver implements WebDriver, SearchContext {
         return newResult;
       }
     } else if (result is List) {
-      return result.map((value) => _recursiveElementify(value)).toList();
+      return result.map(_recursiveElementify).toList();
     } else {
       return result;
     }

--- a/lib/src/sync/json_wire_spec/web_driver.dart
+++ b/lib/src/sync/json_wire_spec/web_driver.dart
@@ -41,9 +41,13 @@ import '../window.dart';
 class JsonWireWebDriver implements WebDriver, SearchContext {
   final CommandProcessor _commandProcessor;
   final Uri _prefix;
+  @override
   final Map<String, dynamic> capabilities;
+  @override
   final String id;
+  @override
   final Uri uri;
+  @override
   final bool filterStackTraces;
 
   @override

--- a/lib/src/sync/json_wire_spec/web_element.dart
+++ b/lib/src/sync/json_wire_spec/web_element.dart
@@ -46,9 +46,8 @@ class JsonWireWebElement implements WebElement, SearchContext {
   @override
   final int index;
 
-  JsonWireWebElement(this.driver, id, [this.context, this.locator, this.index])
-      : this.id = id,
-        _elementPrefix = 'element/$id',
+  JsonWireWebElement(this.driver, this.id, [this.context, this.locator, this.index])
+      : _elementPrefix = 'element/$id',
         _resolver = new Resolver(driver, 'element/$id');
 
   @override
@@ -119,7 +118,7 @@ class JsonWireWebElement implements WebElement, SearchContext {
   List<WebElement> findElements(By by) {
     final elements = _resolver.post('elements', byToJson(by)) as Iterable;
     int i = 0;
-    final webElements = new List<WebElement>();
+    final webElements = <WebElement>[];
     for (final element in elements) {
       webElements.add(new JsonWireWebElement(
           driver, element[jsonWireElementStr], this, by, i++));

--- a/lib/src/sync/json_wire_spec/web_element.dart
+++ b/lib/src/sync/json_wire_spec/web_element.dart
@@ -46,7 +46,8 @@ class JsonWireWebElement implements WebElement, SearchContext {
   @override
   final int index;
 
-  JsonWireWebElement(this.driver, this.id, [this.context, this.locator, this.index])
+  JsonWireWebElement(this.driver, this.id,
+      [this.context, this.locator, this.index])
       : _elementPrefix = 'element/$id',
         _resolver = new Resolver(driver, 'element/$id');
 

--- a/lib/src/sync/json_wire_spec/window.dart
+++ b/lib/src/sync/json_wire_spec/window.dart
@@ -67,7 +67,7 @@ class JsonWireWindow implements Window {
   }
 
   @override
-  void set rect(Rectangle<int> location) {
+  set rect(Rectangle<int> location) {
     setSize(location);
     setLocation(new Point(location.left, location.top));
   }

--- a/lib/src/sync/w3c_spec/element_finder.dart
+++ b/lib/src/sync/w3c_spec/element_finder.dart
@@ -61,7 +61,7 @@ class ElementFinder {
         _resolver.post('elements', _byToJson(by)) as List<Map<String, String>>;
 
     // "as List<String>;" should not be necessary, but helps IntelliJ
-    final ids = elements.fold(new List<String>(), (cur, m) {
+    final ids = elements.fold(<String>[], (cur, m) {
       cur.addAll(m.values);
       return cur;
     }) as List<String>;

--- a/lib/src/sync/w3c_spec/navigation.dart
+++ b/lib/src/sync/w3c_spec/navigation.dart
@@ -23,16 +23,20 @@ class W3cNavigation implements Navigation {
   W3cNavigation(this._driver) : _resolver = new Resolver(_driver, '');
 
   ///  Navigate forwards in the browser history, if possible.
+  @override
   void forward() {
     _resolver.post('forward', {});
   }
 
   /// Navigate backwards in the browser history, if possible.
+
+  @override
   void back() {
     _resolver.post('back', {});
   }
 
   /// Refresh the current page.
+  @override
   void refresh() {
     _resolver.post('refresh', {});
   }

--- a/lib/src/sync/w3c_spec/web_driver.dart
+++ b/lib/src/sync/w3c_spec/web_driver.dart
@@ -56,13 +56,11 @@ class W3cWebDriver implements WebDriver, SearchContext {
   @override
   bool notifyListeners = true;
 
-  final _commandListeners = new List<WebDriverListener>();
+  final _commandListeners = <WebDriverListener>[];
 
-  W3cWebDriver(this._commandProcessor, Uri uri, String id, this.capabilities,
+  W3cWebDriver(this._commandProcessor, this.uri, this.id, this.capabilities,
       {this.filterStackTraces: true})
-      : this.uri = uri,
-        this.id = id,
-        this._prefix = uri.resolve('session/$id/') {
+      : this._prefix = uri.resolve('session/$id/') {
     _finder = new ElementFinder(this, new Resolver(driver, ''), this);
   }
 
@@ -178,7 +176,7 @@ class W3cWebDriver implements WebDriver, SearchContext {
         return newResult;
       }
     } else if (result is List) {
-      return result.map((value) => _recursiveElementify(value)).toList();
+      return result.map(_recursiveElementify).toList();
     } else {
       return result;
     }

--- a/lib/src/sync/w3c_spec/web_driver.dart
+++ b/lib/src/sync/w3c_spec/web_driver.dart
@@ -43,9 +43,13 @@ import '../window.dart';
 class W3cWebDriver implements WebDriver, SearchContext {
   final CommandProcessor _commandProcessor;
   final Uri _prefix;
+  @override
   final Map<String, dynamic> capabilities;
+  @override
   final String id;
+  @override
   final Uri uri;
+  @override
   final bool filterStackTraces;
   ElementFinder _finder;
 

--- a/lib/src/sync/w3c_spec/web_element.dart
+++ b/lib/src/sync/w3c_spec/web_element.dart
@@ -47,9 +47,8 @@ class W3cWebElement implements WebElement, SearchContext {
   @override
   final int index;
 
-  W3cWebElement(this.driver, id, [this.context, this.locator, this.index])
-      : this.id = id,
-        _elementPrefix = 'element/$id',
+  W3cWebElement(this.driver, this.id, [this.context, this.locator, this.index])
+      : _elementPrefix = 'element/$id',
         _resolver = new Resolver(driver, 'element/$id') {
     _finder = new ElementFinder(driver, _resolver, this);
   }

--- a/lib/src/sync/w3c_spec/window.dart
+++ b/lib/src/sync/w3c_spec/window.dart
@@ -70,7 +70,7 @@ class W3cWindow implements Window {
   }
 
   @override
-  void set rect(Rectangle<int> location) => _windowResolver.post('rect', {
+  set rect(Rectangle<int> location) => _windowResolver.post('rect', {
         'x': location.left,
         'y': location.top,
         'width': location.width,

--- a/lib/src/sync/web_element.dart
+++ b/lib/src/sync/web_element.dart
@@ -30,6 +30,7 @@ abstract class WebElement implements SearchContext {
   /// The context from which this element was found.
   SearchContext get context;
 
+  @override
   WebDriver get driver;
 
   /// How the element was located from the context.
@@ -85,9 +86,11 @@ abstract class WebElement implements SearchContext {
   ///Find an element nested within this element.
   ///
   /// Throws [NoSuchElementException] if matching element is not found.
+  @override
   WebElement findElement(By by);
 
   /// Find multiple elements nested within this element.
+  @override
   List<WebElement> findElements(By by);
 
   /// Access to the HTML attributes of this tag.

--- a/lib/src/sync/window.dart
+++ b/lib/src/sync/window.dart
@@ -39,7 +39,7 @@ abstract class Window {
   Rectangle<int> get rect;
 
   /// The location and size of the window.
-  void set rect(Rectangle<int> location);
+  set rect(Rectangle<int> location);
 
   /// Maximize the window.
   void maximize();

--- a/lib/support/async.dart
+++ b/lib/support/async.dart
@@ -79,9 +79,9 @@ class Clock {
   }
 }
 
-_unittestExpect(value, ut.Matcher matcher) => ut.expect(value, matcher);
+void _unittestExpect(value, ut.Matcher matcher) => ut.expect(value, matcher);
 
-_matcherExpect(value, m.Matcher matcher) {
+void _matcherExpect(value, m.Matcher matcher) {
   var matchState = {};
   if (matcher.matches(value, matchState)) {
     return;

--- a/lib/support/async.dart
+++ b/lib/support/async.dart
@@ -97,7 +97,7 @@ void _matcherExpect(value, m.Matcher matcher) {
   var mismatchDescription = new m.StringDescription();
   matcher.describeMismatch(value, mismatchDescription, matchState, true);
   if (mismatchDescription.length > 0) {
-    desc.add('   Which: ${mismatchDescription}\n');
+    desc.add('   Which: $mismatchDescription\n');
   }
   throw new Exception(desc.toString());
 }

--- a/lib/support/firefox_profile.dart
+++ b/lib/support/firefox_profile.dart
@@ -139,7 +139,7 @@ class FirefoxProfile {
           new io.File(path.join(profileDirectory.absolute.path, 'user.js'));
       if (userPrefsFile.existsSync()) {
         _userPrefs = loadPrefsFile(userPrefsFile)
-            .where((option) => !lockedPrefs.contains(option));
+            .where((option) => !lockedPrefs.contains(option)).toSet();
       }
     }
     _prefs.addAll(lockedPrefs);

--- a/lib/support/firefox_profile.dart
+++ b/lib/support/firefox_profile.dart
@@ -139,7 +139,8 @@ class FirefoxProfile {
           new io.File(path.join(profileDirectory.absolute.path, 'user.js'));
       if (userPrefsFile.existsSync()) {
         _userPrefs = loadPrefsFile(userPrefsFile)
-            .where((option) => !lockedPrefs.contains(option)).toSet();
+            .where((option) => !lockedPrefs.contains(option))
+            .toSet();
       }
     }
     _prefs.addAll(lockedPrefs);

--- a/lib/support/firefox_profile.dart
+++ b/lib/support/firefox_profile.dart
@@ -206,7 +206,7 @@ class FirefoxProfile {
           print('Can\'t parse lines from file "${file.path}":');
           canNotParseCaption = false;
         }
-        print('  ${line}');
+        print('  $line');
         continue;
       }
       prefs.add(option);
@@ -228,7 +228,7 @@ class FirefoxProfile {
         ArchiveFile archiveFile;
         final name = path.relative(f.path, from: profileDirectory.path);
         if (f is io.Directory) {
-          archiveFile = new ArchiveFile('${name}/', 0, []);
+          archiveFile = new ArchiveFile('$name/', 0, []);
         } else if (f is io.File) {
           if (name == 'prefs.js' || name == 'user.js') {
             return;
@@ -287,7 +287,7 @@ abstract class PrefsOption<T> {
   factory PrefsOption.parse(String prefs) {
     final match = _preferencePattern.firstMatch(prefs);
     if (match == null) {
-      return new InvalidOption('Not a valid prefs option: "${prefs}".')
+      return new InvalidOption('Not a valid prefs option: "$prefs".')
           as PrefsOption<T>;
     }
     final name = match.group(1);
@@ -308,7 +308,7 @@ abstract class PrefsOption<T> {
       int value = int.parse(valueString);
       return new IntegerOption(name, value) as PrefsOption<T>;
     } catch (_) {}
-    return new InvalidOption('Not a valid prefs option: "${prefs}".')
+    return new InvalidOption('Not a valid prefs option: "$prefs".')
         as PrefsOption<T>;
   }
 
@@ -327,7 +327,7 @@ abstract class PrefsOption<T> {
   @override
   int get hashCode => name.hashCode;
 
-  String get asPrefString => 'user_pref("${name}", ${_valueAsPrefString});';
+  String get asPrefString => 'user_pref("$name", $_valueAsPrefString);';
 
   String get _valueAsPrefString;
 }

--- a/lib/support/stdio_stepper.dart
+++ b/lib/support/stdio_stepper.dart
@@ -24,9 +24,7 @@ LineReader _stdinLineReader;
 
 /// A [LineReader] instance connected to 'dart:io' [stdin].
 LineReader get stdinLineReader {
-  if (_stdinLineReader == null) {
-    _stdinLineReader = new LineReader(stdin);
-  }
+  _stdinLineReader ??= new LineReader(stdin);
   return _stdinLineReader;
 }
 

--- a/lib/support/stdio_stepper.dart
+++ b/lib/support/stdio_stepper.dart
@@ -74,7 +74,7 @@ class StdioStepper implements Stepper {
     throw new Exception('stdin has been closed');
   }
 
-  _printUsage() {
+  void _printUsage() {
     print('`c` or `continue`: execute command');
     print('`s` or `skip`: skip command');
     print('`d` or `disable`: disable stepper');

--- a/lib/sync_core.dart
+++ b/lib/sync_core.dart
@@ -54,13 +54,9 @@ WebDriver createDriver(
     {Uri uri,
     Map<String, dynamic> desired,
     WebDriverSpec spec = WebDriverSpec.JsonWire}) {
-  if (uri == null) {
-    uri = defaultUri;
-  }
+  uri ??= defaultUri;
 
-  if (desired == null) {
-    desired = Capabilities.empty;
-  }
+  desired ??= Capabilities.empty;
 
   switch (spec) {
     case WebDriverSpec.JsonWire:
@@ -93,9 +89,7 @@ WebDriver createDriver(
 
 WebDriver fromExistingSession(String sessionId,
     {Uri uri, WebDriverSpec spec = WebDriverSpec.JsonWire}) {
-  if (uri == null) {
-    uri = defaultUri;
-  }
+  uri ??= defaultUri;
 
   switch (spec) {
     case WebDriverSpec.JsonWire:
@@ -109,7 +103,7 @@ WebDriver fromExistingSession(String sessionId,
       final processor =
           new SyncHttpCommandProcessor(processor: processW3cResponse);
       return new w3c.W3cWebDriver(
-          processor, uri, sessionId, new Map<String, dynamic>());
+          processor, uri, sessionId, const <String, dynamic>{});
     case WebDriverSpec.Auto:
       throw 'Not supported!';
     default:

--- a/test/async_alert_test.dart
+++ b/test/async_alert_test.dart
@@ -72,5 +72,5 @@ void main() {
       await alert.accept();
       expect(await output.text, endsWith('some keys'));
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/async_alert_test.dart
+++ b/test/async_alert_test.dart
@@ -41,7 +41,7 @@ void main() {
     });
 
     test('no alert', () {
-      expect(driver.switchTo.alert, throws);
+      expect(driver.switchTo.alert, throwsA(anything));
     });
 
     test('text', () async {

--- a/test/async_keyboard_test.dart
+++ b/test/async_keyboard_test.dart
@@ -74,5 +74,5 @@ void main() {
       await driver.keyboard.sendKeys('xxx');
       expect(await textInput.attributes['value'], 'xxx');
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/async_logs_test.dart
+++ b/test/async_logs_test.dart
@@ -48,5 +48,5 @@ void main() {
         expect(entry.level, equals(LogLevel.info));
       });
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/async_mouse_test.dart
+++ b/test/async_mouse_test.dart
@@ -76,5 +76,5 @@ void main() {
       var alert = await driver.switchTo.alert;
       await alert.dismiss();
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/async_navigation_test.dart
+++ b/test/async_navigation_test.dart
@@ -49,5 +49,5 @@ void main() {
         return 'expected StaleElementReferenceException';
       });
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/async_options_test.dart
+++ b/test/async_options_test.dart
@@ -101,9 +101,9 @@ void main() {
 
     // TODO(DrMarcII): Figure out how to tell if timeouts are correctly set
     test('set all timeouts', () async {
-      await driver.timeouts.setScriptTimeout(new Duration(seconds: 5));
-      await driver.timeouts.setImplicitTimeout(new Duration(seconds: 1));
-      await driver.timeouts.setPageLoadTimeout(new Duration(seconds: 10));
+      await driver.timeouts.setScriptTimeout(const Duration(seconds: 5));
+      await driver.timeouts.setImplicitTimeout(const Duration(seconds: 1));
+      await driver.timeouts.setPageLoadTimeout(const Duration(seconds: 10));
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/async_target_locator_test.dart
+++ b/test/async_target_locator_test.dart
@@ -20,10 +20,8 @@ import 'package:webdriver/async_core.dart';
 
 import 'io_config.dart' as config;
 
-/**
- * Tests for switchTo.frame(). switchTo.window() and switchTo.alert are tested
- * in other classes.
- */
+/// Tests for switchTo.frame(). switchTo.window() and switchTo.alert are tested
+/// in other classes.
 void main() {
   group('TargetLocator', () {
     WebDriver driver;

--- a/test/async_target_locator_test.dart
+++ b/test/async_target_locator_test.dart
@@ -60,5 +60,5 @@ void main() {
       await driver.switchTo.frame();
       await driver.findElement(const By.tagName('button'));
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/async_web_driver_test.dart
+++ b/test/async_web_driver_test.dart
@@ -52,7 +52,6 @@ void main() {
       test('get', () async {
         await driver.get(config.testPagePath);
         await driver.findElement(const By.tagName('button'));
-        ;
       });
 
       test('currentUrl', () async {
@@ -181,11 +180,11 @@ void main() {
       test('future based event listeners work with script timeouts', () async {
         driver.addEventListener((WebDriverCommandEvent e) async {
           return await new Future.delayed(
-              new Duration(milliseconds: 1000), (() {}));
+              const Duration(milliseconds: 1000), (() {}));
         });
 
         try {
-          driver.timeouts.setScriptTimeout(new Duration(seconds: 1));
+          driver.timeouts.setScriptTimeout(const Duration(seconds: 1));
           await driver.executeAsync('', []);
           fail('Did not throw timeout as expected');
         } catch (e) {
@@ -194,7 +193,7 @@ void main() {
       });
 
       test('future based event listeners ordered appropriately', () async {
-        var eventList = new List<int>();
+        var eventList = <int>[];
         int millisDelay = 2000;
         int current = 0;
         driver.addEventListener((WebDriverCommandEvent e) async {
@@ -214,5 +213,5 @@ void main() {
         }
       });
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/async_web_element_test.dart
+++ b/test/async_web_element_test.dart
@@ -188,5 +188,5 @@ void main() {
       var element = await driver.findElement(const By.cssSelector('table'));
       expect(await element.equals(table), isTrue);
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/async_window_test.dart
+++ b/test/async_window_test.dart
@@ -71,5 +71,5 @@ void main() {
       expect(size.height, greaterThan(200));
       expect(size.width, greaterThan(300));
     }, skip: 'unreliable');
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/support/async_test.dart
+++ b/test/support/async_test.dart
@@ -56,7 +56,7 @@ void main() {
     test('awaitChecking throws exception on acquire of held lock', () async {
       var lock = new Lock(awaitChecking: true);
       await lock.acquire();
-      expect(lock.acquire(), throws);
+      expect(lock.acquire(), throwsA(anything));
       lock.release();
       await lock.acquire();
       lock.release();
@@ -210,6 +210,7 @@ class FakeClock extends Clock {
   @override
   DateTime get now => _now;
 
+  @override
   Future sleep([Duration interval = defaultInterval]) {
     _now = _now.add(interval);
     return new Future.value();

--- a/test/support/async_test.dart
+++ b/test/support/async_test.dart
@@ -200,7 +200,7 @@ void main() {
       }
       expect(exception, isNotNull);
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }
 
 /// FakeClock for testing waitFor functionality.

--- a/test/support/firefox_profile_test.dart
+++ b/test/support/firefox_profile_test.dart
@@ -169,7 +169,7 @@ void main() {
           anyElement((PrefsOption o) =>
               o.name == Capabilities.hasNativeEvents && o.value == true));
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }
 
 Archive unpackArchiveData(Map profileData) {

--- a/test/support/forwarder_test.dart
+++ b/test/support/forwarder_test.dart
@@ -152,5 +152,5 @@ void main() {
     test('window close', () async {
       await forwardedDriver.close();
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/alert.dart
+++ b/test/sync/alert.dart
@@ -75,5 +75,5 @@ void runTests(config.createTestDriver createTestDriver) {
       alert.accept();
       expect(output.text, endsWith('some keys'));
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/basic_sync.dart
+++ b/test/sync/basic_sync.dart
@@ -45,5 +45,5 @@ void runTests(config.createTestDriver createTestDriver) {
     test('can do basic delete', () {
       driver.cookies.deleteAll(); // This is a DELETE request.
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/command_event.dart
+++ b/test/sync/command_event.dart
@@ -61,5 +61,5 @@ void runTests(config.createTestDriver createTestDriver) {
       expect(events[1].startTime.isBefore(events[1].endTime), isTrue);
       expect(events[1].stackTrace, new isInstanceOf<Chain>());
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/cookies.dart
+++ b/test/sync/cookies.dart
@@ -83,5 +83,5 @@ void runTests(config.createTestDriver createTestDriver) {
       driver.cookies.deleteAll();
       expect(driver.cookies.all.toList(), isEmpty);
     }, skip: 'unreliable');
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/keyboard.dart
+++ b/test/sync/keyboard.dart
@@ -73,5 +73,5 @@ void runTests(config.createTestDriver createTestDriver) {
       driver.keyboard.sendKeys('xxx');
       expect(textInput.attributes['value'], 'xxx');
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/logs.dart
+++ b/test/sync/logs.dart
@@ -47,5 +47,5 @@ void runTests(config.createTestDriver createTestDriver) {
         expect(entry.level, equals(LogLevel.info));
       });
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/mouse.dart
+++ b/test/sync/mouse.dart
@@ -76,5 +76,5 @@ void runTests(config.createTestDriver createTestDriver) {
       var alert = driver.switchTo.alert;
       alert.dismiss();
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/navigation.dart
+++ b/test/sync/navigation.dart
@@ -46,5 +46,5 @@ void runTests(config.createTestDriver createTestDriver) {
       }
       return 'expected Exception';
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/spec_inference_test.dart
+++ b/test/sync/spec_inference_test.dart
@@ -60,5 +60,5 @@ void main() {
         expect(e.toString(), contains('Unable to locate element'));
       }
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/sync_async_interop.dart
+++ b/test/sync/sync_async_interop.dart
@@ -65,8 +65,8 @@ void runTests(config.createTestDriver createTestDriver) {
       final element = table.findElement(const By.tagName('tr'));
       final asyncElement =
           await asyncTable.findElement(const async_core.By.tagName('tr'));
-      expect(element.id, await asyncElement.id);
+      expect(element.id, asyncElement.id);
       expect(element.name, await asyncElement.name);
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/target_locator.dart
+++ b/test/sync/target_locator.dart
@@ -20,10 +20,9 @@ import 'package:webdriver/sync_core.dart';
 
 import 'sync_io_config.dart' as config;
 
-/**
- * Tests for switchTo.frame(). switchTo.window() and switchTo.alert are tested
- * in other classes.
- */
+
+/// Tests for switchTo.frame(). switchTo.window() and switchTo.alert are tested
+/// in other classes.
 void runTests(config.createTestDriver createTestDriver) {
   group('TargetLocator', () {
     WebDriver driver;

--- a/test/sync/target_locator.dart
+++ b/test/sync/target_locator.dart
@@ -20,7 +20,6 @@ import 'package:webdriver/sync_core.dart';
 
 import 'sync_io_config.dart' as config;
 
-
 /// Tests for switchTo.frame(). switchTo.window() and switchTo.alert are tested
 /// in other classes.
 void runTests(config.createTestDriver createTestDriver) {

--- a/test/sync/target_locator.dart
+++ b/test/sync/target_locator.dart
@@ -69,5 +69,5 @@ void runTests(config.createTestDriver createTestDriver) {
       driver.switchTo.frame();
       driver.findElement(const By.tagName('button'));
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/timeouts.dart
+++ b/test/sync/timeouts.dart
@@ -37,9 +37,9 @@ void runTests(config.createTestDriver createTestDriver) {
 
     // TODO(DrMarcII): Figure out how to tell if timeouts are correctly set
     test('set all timeouts', () {
-      driver.timeouts.setScriptTimeout(new Duration(seconds: 5));
-      driver.timeouts.setImplicitTimeout(new Duration(seconds: 1));
-      driver.timeouts.setPageLoadTimeout(new Duration(seconds: 10));
+      driver.timeouts.setScriptTimeout(const Duration(seconds: 5));
+      driver.timeouts.setImplicitTimeout(const Duration(seconds: 1));
+      driver.timeouts.setPageLoadTimeout(const Duration(seconds: 10));
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/w3c_web_element.dart
+++ b/test/sync/w3c_web_element.dart
@@ -65,7 +65,7 @@ void runTests(config.createTestDriver createTestDriver) {
 
     test('sendKeys', () {
       textInput.sendKeys('some keys');
-      sleep(new Duration(milliseconds: 500));
+      sleep(const Duration(milliseconds: 500));
       expect(textInput.properties['value'], 'some keys');
     });
 
@@ -181,5 +181,5 @@ void runTests(config.createTestDriver createTestDriver) {
       var element = driver.findElement(const By.cssSelector('table'));
       expect(element.equals(table), isTrue);
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/web_driver.dart
+++ b/test/sync/web_driver.dart
@@ -51,7 +51,6 @@ void runTests(config.createTestDriver createTestDriver) {
       test('get', () {
         driver.get(config.testPagePath);
         driver.findElement(const By.tagName('button'));
-        ;
       });
 
       test('currentUrl', () {
@@ -100,7 +99,7 @@ void runTests(config.createTestDriver createTestDriver) {
       test('close/windows', () {
         int numHandles = (driver.windows.toList()).length;
         (driver.findElement(const By.partialLinkText('Open copy'))).click();
-        sleep(new Duration(milliseconds: 500)); // Bit slow on Firefox.
+        sleep(const Duration(milliseconds: 500)); // Bit slow on Firefox.
         expect(driver.windows.toList(), hasLength(numHandles + 1));
         driver.close();
         expect(driver.windows.toList(), hasLength(numHandles));
@@ -111,7 +110,7 @@ void runTests(config.createTestDriver createTestDriver) {
         Window next;
 
         (driver.findElement(const By.partialLinkText('Open copy'))).click();
-        sleep(new Duration(milliseconds: 500)); // Bit slow on Firefox.
+        sleep(const Duration(milliseconds: 500)); // Bit slow on Firefox.
         for (final window in driver.windows) {
           if (window != orig) {
             next = window;
@@ -175,7 +174,7 @@ void runTests(config.createTestDriver createTestDriver) {
 
       test('event listeners work with script timeouts', () {
         try {
-          driver.timeouts.setScriptTimeout(new Duration(seconds: 1));
+          driver.timeouts.setScriptTimeout(const Duration(seconds: 1));
           driver.executeAsync('', []);
           fail('Did not throw timeout as expected');
         } catch (e) {
@@ -186,7 +185,7 @@ void runTests(config.createTestDriver createTestDriver) {
       });
 
       test('event listeners ordered appropriately', () {
-        var eventList = new List<int>();
+        var eventList = <int>[];
         int current = 0;
         driver.addEventListener((WebDriverCommandEvent e) {
           eventList.add(current++);
@@ -201,5 +200,5 @@ void runTests(config.createTestDriver createTestDriver) {
         }
       });
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/web_element.dart
+++ b/test/sync/web_element.dart
@@ -188,5 +188,5 @@ void runTests(config.createTestDriver createTestDriver) {
       var element = driver.findElement(const By.cssSelector('table'));
       expect(element.equals(table), isTrue);
     });
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/window.dart
+++ b/test/sync/window.dart
@@ -61,5 +61,5 @@ void runTests(config.createTestDriver createTestDriver) {
       expect(finalRect.width, greaterThan(300));
       expect(finalRect.height, greaterThan(300));
     }, skip: 'Unreliable on Travis');
-  }, timeout: new Timeout(new Duration(minutes: 2)));
+  }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/window.dart
+++ b/test/sync/window.dart
@@ -15,7 +15,7 @@
 @TestOn("vm")
 library webdriver.window_test;
 
-import 'dart:math' show Point, Rectangle;
+import 'dart:math' show Rectangle;
 
 import 'package:test/test.dart';
 import 'package:webdriver/sync_core.dart';


### PR DESCRIPTION
This PR adds a lot of analyzer lints and cleans up most of them. All previously passing tests are still locally passing (all chrome tests pass, 12 firefox tests don't).

There are no functionality changes or API changes.

Most of the cleanups in this PR are:
- Prefer const constructors (new Duration -> const Duration)
- Specifiy return types
- Prefer using this.x instead of x : this.x = x
- Prefer using collection literals (new List<x>() -> <x>[])
- Remove unnecessary string interpolations (${x} -> $x)
- Add missing @override
- Replace deprecated matcher 'throws' with 'throwsA(anything)'