### PR TITLE
Fix (some) Dart 2 runtime cast errors

### DIFF
--- a/lib/src/async/common.dart
+++ b/lib/src/async/common.dart
@@ -21,7 +21,7 @@ const String _element = 'ELEMENT';
 class Attributes extends _WebDriverBase {
   Attributes._(driver, command) : super(driver, command);
 
-  Future<String> operator [](String name) => _get(name) as Future<String>;
+  Future<String> operator [](String name) => _get<String>(name);
 }
 
 abstract class SearchContext {
@@ -45,7 +45,7 @@ abstract class _WebDriverBase {
   Future _post(String command, [param]) =>
       driver.postRequest(_resolve(command), param);
 
-  Future _get(String command) => driver.getRequest(_resolve(command));
+  Future<T> _get<T>(String command) => driver.getRequest(_resolve(command));
 
   Future _delete(String command) => driver.deleteRequest(_resolve(command));
 

--- a/lib/src/async/web_driver.dart
+++ b/lib/src/async/web_driver.dart
@@ -47,7 +47,7 @@ class WebDriver implements SearchContext {
       _commandListeners.add(listener);
 
   /// The current url.
-  Future<String> get currentUrl => getRequest('url') as Future<String>;
+  Future<String> get currentUrl => getRequest<String>('url');
 
   /// navigate to the specified url
   Future get(/* Uri | String */ url) async {
@@ -58,7 +58,7 @@ class WebDriver implements SearchContext {
   }
 
   /// The title of the current page.
-  Future<String> get title => getRequest('title') as Future<String>;
+  Future<String> get title => getRequest<String>('title');
 
   /// Search for multiple elements within the entire current page.
   @override
@@ -81,7 +81,7 @@ class WebDriver implements SearchContext {
   }
 
   /// An artist's rendition of the current page's source.
-  Future<String> get pageSource => getRequest('source') as Future<String>;
+  Future<String> get pageSource => getRequest<String>('source');
 
   /// Close the current window, quitting the browser if it is the last window.
   Future close() async {
@@ -215,16 +215,17 @@ class WebDriver implements SearchContext {
     }
   }
 
-  Future postRequest(String command, [params]) => _performRequestWithLog(
-      () => _commandProcessor.post(_resolve(command), params),
-      'POST',
-      command,
-      params);
+  Future<T> postRequest<T>(String command, [params]) =>
+      _performRequestWithLog<T>(
+          () => _commandProcessor.post(_resolve(command), params),
+          'POST',
+          command,
+          params);
 
-  Future getRequest(String command) => _performRequestWithLog(
+  Future<T> getRequest<T>(String command) => _performRequestWithLog<T>(
       () => _commandProcessor.get(_resolve(command)), 'GET', command, null);
 
-  Future deleteRequest(String command) => _performRequestWithLog(
+  Future<T> deleteRequest<T>(String command) => _performRequestWithLog<T>(
       () => _commandProcessor.delete(_resolve(command)),
       'DELETE',
       command,
@@ -232,9 +233,9 @@ class WebDriver implements SearchContext {
 
   // Performs request and sends the result to listeners/onCommandController.
   // This is typically always what you want to use.
-  Future _performRequestWithLog(
+  Future<T> _performRequestWithLog<T>(
       Function fn, String method, String command, params) async {
-    return await _performRequest(fn, method, command, params)
+    return await _performRequest<T>(fn, method, command, params)
         .whenComplete(() async {
       if (notifyListeners) {
         if (_previousEvent == null) {
@@ -254,7 +255,7 @@ class WebDriver implements SearchContext {
   // Performs the request. This will not notify any listeners or
   // onCommandController. This should only be called from
   // _performRequestWithLog.
-  Future _performRequest(
+  Future<T> _performRequest<T>(
       Function fn, String method, String command, params) async {
     var startTime = new DateTime.now();
     var trace = new Chain.current();

--- a/lib/src/async/web_element.dart
+++ b/lib/src/async/web_element.dart
@@ -53,13 +53,13 @@ class WebElement extends _WebDriverBase implements SearchContext {
   }
 
   /// Is this radio button/checkbox selected?
-  Future<bool> get selected => _get('selected') as Future<bool>;
+  Future<bool> get selected => _get<bool>('selected');
 
   /// Is this form element enabled?
-  Future<bool> get enabled => _get('enabled') as Future<bool>;
+  Future<bool> get enabled => _get<bool>('enabled');
 
   /// Is this element visible in the page?
-  Future<bool> get displayed => _get('displayed') as Future<bool>;
+  Future<bool> get displayed => _get<bool>('displayed');
 
   /// The location within the document of this element.
   Future<Point> get location async {
@@ -75,10 +75,10 @@ class WebElement extends _WebDriverBase implements SearchContext {
   }
 
   /// The tag name for this element.
-  Future<String> get name => _get('name') as Future<String>;
+  Future<String> get name => _get<String>('name');
 
   ///  Visible text within this element.
-  Future<String> get text => _get('text') as Future<String>;
+  Future<String> get text => _get<String>('text');
 
   ///Find an element nested within this element.
   ///
@@ -113,8 +113,7 @@ class WebElement extends _WebDriverBase implements SearchContext {
 
   /// Does this element represent the same element as another element?
   /// Not the same as ==
-  Future<bool> equals(WebElement other) =>
-      _get('equals/${other.id}') as Future<bool>;
+  Future<bool> equals(WebElement other) => _get<bool>('equals/${other.id}');
 
   Map<String, String> toJson() => {_element: id};
 

--- a/lib/src/sync/json_wire_spec/window.dart
+++ b/lib/src/sync/json_wire_spec/window.dart
@@ -30,8 +30,8 @@ class JsonWireWindows implements Windows {
 
   @override
   List<Window> get allWindows =>
-      (_resolver.get('window_handles') as List<String>)
-          .map((handle) => new JsonWireWindow(_driver, handle))
+      (_resolver.get('window_handles').retype<String>())
+          .map<Window>((handle) => new JsonWireWindow(_driver, handle))
           .toList();
 }
 


### PR DESCRIPTION
These errors are not easily reproduced. `pub` does not yet sport a `--preview-dart-2` flag yet. But I can confirm that this PR fixes most of the runtime issues I've seen internally.

This PR doesn't appear to break any tests.