### PR TITLE
Minor fixes for styles

### DIFF
--- a/lib/async_core.dart
+++ b/lib/async_core.dart
@@ -16,7 +16,7 @@ library webdriver.core;
 
 import 'dart:async' show Future, Stream, StreamController;
 import 'dart:collection' show UnmodifiableMapView;
-import 'dart:convert' show BASE64;
+import 'dart:convert' show base64;
 import 'dart:math' show Point, Rectangle;
 
 import 'package:stack_trace/stack_trace.dart' show Chain;

--- a/lib/async_io.dart
+++ b/lib/async_io.dart
@@ -15,7 +15,7 @@
 library webdriver.io;
 
 import 'dart:async' show Future;
-import 'dart:convert' show JSON, UTF8;
+import 'dart:convert' show json, utf8;
 import 'dart:io'
     show
         ContentType,
@@ -50,7 +50,7 @@ Future<core.WebDriver> fromExistingSession(String sessionId, {Uri uri}) =>
     core.fromExistingSession(new IOCommandProcessor(), sessionId, uri: uri);
 
 final ContentType _contentTypeJson =
-    new ContentType("application", "json", charset: "utf-8");
+    new ContentType('application', 'json', charset: 'utf-8');
 
 class IOCommandProcessor implements CommandProcessor {
   final HttpClient client = new HttpClient();
@@ -64,7 +64,7 @@ class IOCommandProcessor implements CommandProcessor {
     _setUpRequest(request);
     request.headers.contentType = _contentTypeJson;
     if (params != null) {
-      var body = UTF8.encode(JSON.encode(params));
+      var body = utf8.encode(json.encode(params));
       request.contentLength = body.length;
       request.add(body);
     } else {
@@ -96,11 +96,11 @@ class IOCommandProcessor implements CommandProcessor {
 
   Future<dynamic> _processResponse(
       HttpClientResponse response, bool value) async {
-    var respDecoded = await UTF8.decodeStream(response);
+    var respDecoded = await utf8.decodeStream(response);
     _lock.release();
     Map respBody;
     try {
-      respBody = JSON.decode(respDecoded);
+      respBody = json.decode(respDecoded);
     } catch (e) {}
 
     if (response.statusCode < 200 ||
@@ -121,8 +121,8 @@ class IOCommandProcessor implements CommandProcessor {
 
   void _setUpRequest(HttpClientRequest request) {
     request.followRedirects = true;
-    request.headers.add(HttpHeaders.ACCEPT, "application/json");
-    request.headers.add(HttpHeaders.ACCEPT_CHARSET, UTF8.name);
-    request.headers.add(HttpHeaders.CACHE_CONTROL, "no-cache");
+    request.headers.add(HttpHeaders.ACCEPT, 'application/json');
+    request.headers.add(HttpHeaders.ACCEPT_CHARSET, utf8.name);
+    request.headers.add(HttpHeaders.CACHE_CONTROL, 'no-cache');
   }
 }

--- a/lib/html.dart
+++ b/lib/html.dart
@@ -15,7 +15,7 @@
 library webdriver.html;
 
 import 'dart:async' show Future;
-import 'dart:convert' show JSON;
+import 'dart:convert' show json;
 import 'dart:html' show HttpRequest, ProgressEvent;
 
 import 'package:webdriver/async_core.dart' as core
@@ -67,9 +67,9 @@ class _HtmlCommandProcessor implements CommandProcessor {
   Future<dynamic> _request(
       String method, Uri uri, dynamic params, bool value) async {
     await _lock.acquire();
-    var sendData;
+    String sendData;
     if (params != null && method == 'POST') {
-      sendData = JSON.encode(params);
+      sendData = json.encode(params);
     }
 
     HttpRequest request;
@@ -87,7 +87,7 @@ class _HtmlCommandProcessor implements CommandProcessor {
     }
     var respBody = request.response;
     try {
-      respBody = JSON.decode(respBody);
+      respBody = json.decode(respBody);
     } catch (e) {}
 
     if (request.status < 200 ||

--- a/lib/src/async/capabilities.dart
+++ b/lib/src/async/capabilities.dart
@@ -16,25 +16,25 @@ part of webdriver.core;
 
 /// Capabilities constants.
 class Capabilities {
-  static const String browserName = "browserName";
-  static const String platform = "platform";
-  static const String supportsJavascript = "javascriptEnabled";
-  static const String takesScreenshot = "takesScreenshot";
-  static const String version = "version";
-  static const String supportsAlerts = "handlesAlerts";
-  static const String supportSqlDatabase = "databaseEnabled";
-  static const String supportsLocationContext = "locationContextEnabled";
-  static const String supportsApplicationCache = "applicationCacheEnabled";
-  static const String supportsBrowserConnection = "browserConnectionEnabled";
-  static const String supportsFindingByCss = "cssSelectorsEnabled";
-  static const String proxy = "proxy";
-  static const String supportsWebStorage = "webStorageEnabled";
-  static const String rotatable = "rotatable";
-  static const String acceptSslCerts = "acceptSslCerts";
-  static const String hasNativeEvents = "nativeEvents";
-  static const String unexpectedAlertBehaviour = "unexpectedAlertBehaviour";
-  static const String loggingPrefs = "loggingPrefs";
-  static const String enableProfiling = "webdriver.logging.profiler.enabled";
+  static const String browserName = 'browserName';
+  static const String platform = 'platform';
+  static const String supportsJavascript = 'javascriptEnabled';
+  static const String takesScreenshot = 'takesScreenshot';
+  static const String version = 'version';
+  static const String supportsAlerts = 'handlesAlerts';
+  static const String supportSqlDatabase = 'databaseEnabled';
+  static const String supportsLocationContext = 'locationContextEnabled';
+  static const String supportsApplicationCache = 'applicationCacheEnabled';
+  static const String supportsBrowserConnection = 'browserConnectionEnabled';
+  static const String supportsFindingByCss = 'cssSelectorsEnabled';
+  static const String proxy = 'proxy';
+  static const String supportsWebStorage = 'webStorageEnabled';
+  static const String rotatable = 'rotatable';
+  static const String acceptSslCerts = 'acceptSslCerts';
+  static const String hasNativeEvents = 'nativeEvents';
+  static const String unexpectedAlertBehaviour = 'unexpectedAlertBehaviour';
+  static const String loggingPrefs = 'loggingPrefs';
+  static const String enableProfiling = 'webdriver.logging.profiler.enabled';
 
   static Map<String, dynamic> get chrome => new Map.from(empty)
     ..[browserName] = Browser.chrome
@@ -51,23 +51,23 @@ class Capabilities {
     ..[version] = ''
     ..[platform] = BrowserPlatform.android;
 
-  static Map<String, dynamic> get empty => new Map<String, dynamic>();
+  static Map<String, dynamic> get empty => <String, dynamic>{};
 }
 
 /// Browser name constants.
 class Browser {
-  static const String firefox = "firefox";
-  static const String safari = "safari";
-  static const String opera = "opera";
-  static const String chrome = "chrome";
-  static const String android = "android";
-  static const String ie = "internet explorer";
-  static const String iphone = "iPhone";
-  static const String ipad = "iPad";
+  static const String firefox = 'firefox';
+  static const String safari = 'safari';
+  static const String opera = 'opera';
+  static const String chrome = 'chrome';
+  static const String android = 'android';
+  static const String ie = 'internet explorer';
+  static const String iphone = 'iPhone';
+  static const String ipad = 'iPad';
 }
 
 /// Browser operating system constants.
 class BrowserPlatform {
-  static const String any = "ANY";
-  static const String android = "ANDROID";
+  static const String any = 'ANY';
+  static const String android = 'ANDROID';
 }

--- a/lib/src/async/exception.dart
+++ b/lib/src/async/exception.dart
@@ -94,7 +94,6 @@ abstract class WebDriverException implements Exception {
 
   @override
   bool operator ==(other) =>
-      other != null &&
       other.runtimeType == this.runtimeType &&
       other.statusCode == this.statusCode &&
       other.message == this.message;

--- a/lib/src/async/web_driver.dart
+++ b/lib/src/async/web_driver.dart
@@ -146,7 +146,7 @@ class WebDriver implements SearchContext {
   /// Take a screenshot of the current page as PNG as list of uint8.
   Future<List<int>> captureScreenshotAsList() async {
     var base64Encoded = captureScreenshotAsBase64();
-    return BASE64.decode(await base64Encoded);
+    return base64.decode(await base64Encoded);
   }
 
   /// Take a screenshot of the current page as PNG as stream of uint8.

--- a/lib/src/sync/capabilities.dart
+++ b/lib/src/sync/capabilities.dart
@@ -14,25 +14,25 @@
 
 /// Capabilities constants.
 class Capabilities {
-  static const String browserName = "browserName";
-  static const String platform = "platform";
-  static const String supportsJavascript = "javascriptEnabled";
-  static const String takesScreenshot = "takesScreenshot";
-  static const String version = "version";
-  static const String supportsAlerts = "handlesAlerts";
-  static const String supportSqlDatabase = "databaseEnabled";
-  static const String supportsLocationContext = "locationContextEnabled";
-  static const String supportsApplicationCache = "applicationCacheEnabled";
-  static const String supportsBrowserConnection = "browserConnectionEnabled";
-  static const String supportsFindingByCss = "cssSelectorsEnabled";
-  static const String proxy = "proxy";
-  static const String supportsWebStorage = "webStorageEnabled";
-  static const String rotatable = "rotatable";
-  static const String acceptSslCerts = "acceptSslCerts";
-  static const String hasNativeEvents = "nativeEvents";
-  static const String unexpectedAlertBehaviour = "unexpectedAlertBehaviour";
-  static const String loggingPrefs = "loggingPrefs";
-  static const String enableProfiling = "webdriver.logging.profiler.enabled";
+  static const String browserName = 'browserName';
+  static const String platform = 'platform';
+  static const String supportsJavascript = 'javascriptEnabled';
+  static const String takesScreenshot = 'takesScreenshot';
+  static const String version = 'version';
+  static const String supportsAlerts = 'handlesAlerts';
+  static const String supportSqlDatabase = 'databaseEnabled';
+  static const String supportsLocationContext = 'locationContextEnabled';
+  static const String supportsApplicationCache = 'applicationCacheEnabled';
+  static const String supportsBrowserConnection = 'browserConnectionEnabled';
+  static const String supportsFindingByCss = 'cssSelectorsEnabled';
+  static const String proxy = 'proxy';
+  static const String supportsWebStorage = 'webStorageEnabled';
+  static const String rotatable = 'rotatable';
+  static const String acceptSslCerts = 'acceptSslCerts';
+  static const String hasNativeEvents = 'nativeEvents';
+  static const String unexpectedAlertBehaviour = 'unexpectedAlertBehaviour';
+  static const String loggingPrefs = 'loggingPrefs';
+  static const String enableProfiling = 'webdriver.logging.profiler.enabled';
 
   static Map<String, dynamic> get chrome => new Map.from(empty)
     ..[browserName] = Browser.chrome
@@ -54,18 +54,18 @@ class Capabilities {
 
 /// Browser name constants.
 class Browser {
-  static const String firefox = "firefox";
-  static const String safari = "safari";
-  static const String opera = "opera";
-  static const String chrome = "chrome";
-  static const String android = "android";
-  static const String ie = "internet explorer";
-  static const String iphone = "iPhone";
-  static const String ipad = "iPad";
+  static const String firefox = 'firefox';
+  static const String safari = 'safari';
+  static const String opera = 'opera';
+  static const String chrome = 'chrome';
+  static const String android = 'android';
+  static const String ie = 'internet explorer';
+  static const String iphone = 'iPhone';
+  static const String ipad = 'iPad';
 }
 
 /// Browser operating system constants.
 class BrowserPlatform {
-  static const String any = "ANY";
-  static const String android = "ANDROID";
+  static const String any = 'ANY';
+  static const String android = 'ANDROID';
 }

--- a/lib/src/sync/command_processor.dart
+++ b/lib/src/sync/command_processor.dart
@@ -14,18 +14,18 @@
 
 library webdriver.command_processor;
 
-import 'dart:convert' show JSON;
+import 'dart:convert' show json;
 import 'dart:io' show ContentType, HttpHeaders;
 
 import 'package:sync_http/sync_http.dart';
 
 final ContentType _contentTypeJson =
-    new ContentType("application", "json", charset: "utf-8");
+    new ContentType('application', 'json', charset: 'utf-8');
 
 typedef dynamic ResponseProcessor(SyncHttpClientResponse response, bool value);
 
 dynamic _defaultProcessor(SyncHttpClientResponse response, bool value) =>
-    JSON.decode(response.body);
+    json.decode(response.body);
 
 /// Interface for synchronous HTTP access.
 abstract class CommandProcessor {
@@ -42,7 +42,7 @@ abstract class CommandProcessor {
 class SyncHttpCommandProcessor implements CommandProcessor {
   final ResponseProcessor _responseProcessor;
 
-  SyncHttpCommandProcessor({ResponseProcessor processor = null})
+  SyncHttpCommandProcessor({ResponseProcessor processor})
       : this._responseProcessor = processor ?? _defaultProcessor;
 
   @override
@@ -51,7 +51,7 @@ class SyncHttpCommandProcessor implements CommandProcessor {
     _setUpRequest(request);
     request.headers.contentType = _contentTypeJson;
     if (params != null) {
-      var body = JSON.encode(params); // Cannot be changed from UTF8.
+      var body = json.encode(params); // Cannot be changed from UTF8.
       request.write(body);
     }
     return _responseProcessor(request.close(), value);
@@ -76,7 +76,7 @@ class SyncHttpCommandProcessor implements CommandProcessor {
 
   void _setUpRequest(SyncHttpClientRequest request) {
     // TODO(staats): Follow redirects.
-    request.headers.add(HttpHeaders.ACCEPT, "application/json");
-    request.headers.add(HttpHeaders.CACHE_CONTROL, "no-cache");
+    request.headers.add(HttpHeaders.ACCEPT, 'application/json');
+    request.headers.add(HttpHeaders.CACHE_CONTROL, 'no-cache');
   }
 }

--- a/lib/src/sync/json_wire_spec/exception.dart
+++ b/lib/src/sync/json_wire_spec/exception.dart
@@ -99,7 +99,6 @@ abstract class JsonWireWebDriverException implements WebDriverException {
 
   @override
   bool operator ==(other) =>
-      other != null &&
       other.runtimeType == this.runtimeType &&
       other.statusCode == this.statusCode &&
       other.message == this.message;

--- a/lib/src/sync/json_wire_spec/response_processor.dart
+++ b/lib/src/sync/json_wire_spec/response_processor.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:convert' show JSON;
+import 'dart:convert' show json;
 
 import 'package:sync_http/sync_http.dart';
 
@@ -22,7 +22,7 @@ import 'exception.dart' show JsonWireWebDriverException;
 dynamic processJsonWireResponse(SyncHttpClientResponse response, bool value) {
   Map responseBody;
   try {
-    responseBody = JSON.decode(response.body);
+    responseBody = json.decode(response.body);
   } catch (e) {}
 
   if (response.statusCode < 200 ||

--- a/lib/src/sync/json_wire_spec/web_driver.dart
+++ b/lib/src/sync/json_wire_spec/web_driver.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:convert' show BASE64;
+import 'dart:convert' show base64;
 import 'package:stack_trace/stack_trace.dart' show Chain;
 
 import 'by.dart' show byToJson;
@@ -166,7 +166,7 @@ class JsonWireWebDriver implements WebDriver, SearchContext {
   @override
   List<int> captureScreenshotAsList() {
     final base64Encoded = captureScreenshotAsBase64();
-    return BASE64.decode(base64Encoded);
+    return base64.decode(base64Encoded);
   }
 
   @override

--- a/lib/src/sync/spec_inference_response_processor.dart
+++ b/lib/src/sync/spec_inference_response_processor.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:convert' show JSON;
+import 'dart:convert' show json;
 
 import 'package:sync_http/sync_http.dart';
 import 'package:webdriver/sync_core.dart';
@@ -30,7 +30,7 @@ class InferredResponse {
 dynamic inferSessionResponseSpec(SyncHttpClientResponse response, bool _) {
   Map responseBody;
   try {
-    responseBody = JSON.decode(response.body);
+    responseBody = json.decode(response.body);
   } catch (e) {}
 
   // TODO(staats): create more description error messages.

--- a/lib/src/sync/w3c_spec/exception.dart
+++ b/lib/src/sync/w3c_spec/exception.dart
@@ -53,7 +53,6 @@ class W3cWebDriverException implements WebDriverException {
 
   @override
   bool operator ==(other) =>
-      other != null &&
       other.runtimeType == this.runtimeType &&
       other.statusCode == this.httpStatusCode &&
       other.message == this.message &&

--- a/lib/src/sync/w3c_spec/response_processor.dart
+++ b/lib/src/sync/w3c_spec/response_processor.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:convert' show JSON;
+import 'dart:convert' show json;
 
 import 'package:sync_http/sync_http.dart';
 
@@ -22,7 +22,7 @@ import 'exception.dart' show W3cWebDriverException;
 dynamic processW3cResponse(SyncHttpClientResponse response, bool value) {
   Map responseBody;
   try {
-    responseBody = JSON.decode(response.body);
+    responseBody = json.decode(response.body);
   } catch (e) {}
 
   if (response.statusCode < 200 || response.statusCode > 299) {

--- a/lib/src/sync/w3c_spec/web_driver.dart
+++ b/lib/src/sync/w3c_spec/web_driver.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:convert' show BASE64;
+import 'dart:convert' show base64;
 import 'package:stack_trace/stack_trace.dart' show Chain;
 
 import 'element_finder.dart';
@@ -152,7 +152,7 @@ class W3cWebDriver implements WebDriver, SearchContext {
   @override
   List<int> captureScreenshotAsList() {
     final base64Encoded = captureScreenshotAsBase64();
-    return BASE64.decode(base64Encoded);
+    return base64.decode(base64Encoded);
   }
 
   @override

--- a/lib/support/async.dart
+++ b/lib/support/async.dart
@@ -26,7 +26,7 @@ const defaultTimeout = const Duration(seconds: 5);
 const clock = const Clock();
 
 Future<T> waitFor<T>(FutureOr<T> condition(),
-        {matcher: null,
+        {matcher,
         Duration timeout: defaultTimeout,
         Duration interval: defaultInterval}) =>
     clock.waitFor<T>(condition,
@@ -51,7 +51,7 @@ class Clock {
   /// rethrown. If [condition] doesn't throw then an [expect] exception is
   /// thrown.
   Future<T> waitFor<T>(FutureOr<T> condition(),
-      {matcher: null,
+      {matcher,
       Duration timeout: defaultTimeout,
       Duration interval: defaultInterval}) async {
     if (matcher != null && matcher is! ut.Matcher && matcher is! m.Matcher) {

--- a/lib/support/firefox_profile.dart
+++ b/lib/support/firefox_profile.dart
@@ -15,7 +15,7 @@
 library webdriver.support.firefox_profile;
 
 import 'dart:collection';
-import 'dart:convert' show LineSplitter, BASE64;
+import 'dart:convert' show LineSplitter, base64;
 import 'dart:io' as io;
 
 import 'package:archive/archive.dart' show Archive, ArchiveFile, ZipEncoder;
@@ -23,77 +23,77 @@ import 'package:path/path.dart' as path;
 
 /// Unmodifiable defaults for 'prefs.js' and 'user.js'.
 final List<PrefsOption> lockedPrefs = <PrefsOption>[
-  new BooleanOption("app.update.auto", false),
-  new BooleanOption("app.update.enabled", false),
-  new IntegerOption("browser.displayedE10SNotice", 4),
-  new BooleanOption("browser.download.manager.showWhenStarting", false),
-  new BooleanOption("browser.EULA.override", true),
-  new BooleanOption("browser.EULA.3.accepted", true),
-  new IntegerOption("browser.link.open_external", 2),
-  new IntegerOption("browser.link.open_newwindow", 2),
-  new BooleanOption("browser.offline", false),
-  new BooleanOption("browser.reader.detectedFirstArticle", true),
-  new BooleanOption("browser.safebrowsing.enabled", false),
-  new BooleanOption("browser.safebrowsing.malware.enabled", false),
-  new BooleanOption("browser.search.update", false),
-  new StringOption("browser.selfsupport.url", ""),
-  new BooleanOption("browser.sessionstore.resume_from_crash", false),
-  new BooleanOption("browser.shell.checkDefaultBrowser", false),
-  new BooleanOption("browser.tabs.warnOnClose", false),
-  new BooleanOption("browser.tabs.warnOnOpen", false),
-  new BooleanOption("datareporting.healthreport.service.enabled", false),
-  new BooleanOption("datareporting.healthreport.uploadEnabled", false),
-  new BooleanOption("datareporting.healthreport.service.firstRun", false),
-  new BooleanOption("datareporting.healthreport.logging.consoleEnabled", false),
-  new BooleanOption("datareporting.policy.dataSubmissionEnabled", false),
-  new BooleanOption("datareporting.policy.dataSubmissionPolicyAccepted", false),
-  new BooleanOption("devtools.errorconsole.enabled", true),
-  new BooleanOption("dom.disable_open_during_load", false),
-  new IntegerOption("extensions.autoDisableScopes", 10),
-  new BooleanOption("extensions.blocklist.enabled", false),
-  new BooleanOption("extensions.logging.enabled", true),
-  new BooleanOption("extensions.update.enabled", false),
-  new BooleanOption("extensions.update.notifyUser", false),
-  new BooleanOption("javascript.enabled", true),
-  new BooleanOption("network.manage-offline-status", false),
-  new IntegerOption("network.http.phishy-userpass-length", 255),
-  new BooleanOption("offline-apps.allow_by_default", true),
-  new BooleanOption("prompts.tab_modal.enabled", false),
-  new BooleanOption("security.csp.enable", false),
-  new IntegerOption("security.fileuri.origin_policy", 3),
-  new BooleanOption("security.fileuri.strict_origin_policy", false),
-  new BooleanOption("security.warn_entering_secure", false),
-  new BooleanOption("security.warn_entering_secure.show_once", false),
-  new BooleanOption("security.warn_entering_weak", false),
-  new BooleanOption("security.warn_entering_weak.show_once", false),
-  new BooleanOption("security.warn_leaving_secure", false),
-  new BooleanOption("security.warn_leaving_secure.show_once", false),
-  new BooleanOption("security.warn_submit_insecure", false),
-  new BooleanOption("security.warn_viewing_mixed", false),
-  new BooleanOption("security.warn_viewing_mixed.show_once", false),
-  new BooleanOption("signon.rememberSignons", false),
-  new BooleanOption("toolkit.networkmanager.disable", true),
-  new IntegerOption("toolkit.telemetry.prompted", 2),
-  new BooleanOption("toolkit.telemetry.enabled", false),
-  new BooleanOption("toolkit.telemetry.rejected", true),
-  new BooleanOption("xpinstall.signatures.required", false),
+  new BooleanOption('app.update.auto', false),
+  new BooleanOption('app.update.enabled', false),
+  new IntegerOption('browser.displayedE10SNotice', 4),
+  new BooleanOption('browser.download.manager.showWhenStarting', false),
+  new BooleanOption('browser.EULA.override', true),
+  new BooleanOption('browser.EULA.3.accepted', true),
+  new IntegerOption('browser.link.open_external', 2),
+  new IntegerOption('browser.link.open_newwindow', 2),
+  new BooleanOption('browser.offline', false),
+  new BooleanOption('browser.reader.detectedFirstArticle', true),
+  new BooleanOption('browser.safebrowsing.enabled', false),
+  new BooleanOption('browser.safebrowsing.malware.enabled', false),
+  new BooleanOption('browser.search.update', false),
+  new StringOption('browser.selfsupport.url', ''),
+  new BooleanOption('browser.sessionstore.resume_from_crash', false),
+  new BooleanOption('browser.shell.checkDefaultBrowser', false),
+  new BooleanOption('browser.tabs.warnOnClose', false),
+  new BooleanOption('browser.tabs.warnOnOpen', false),
+  new BooleanOption('datareporting.healthreport.service.enabled', false),
+  new BooleanOption('datareporting.healthreport.uploadEnabled', false),
+  new BooleanOption('datareporting.healthreport.service.firstRun', false),
+  new BooleanOption('datareporting.healthreport.logging.consoleEnabled', false),
+  new BooleanOption('datareporting.policy.dataSubmissionEnabled', false),
+  new BooleanOption('datareporting.policy.dataSubmissionPolicyAccepted', false),
+  new BooleanOption('devtools.errorconsole.enabled', true),
+  new BooleanOption('dom.disable_open_during_load', false),
+  new IntegerOption('extensions.autoDisableScopes', 10),
+  new BooleanOption('extensions.blocklist.enabled', false),
+  new BooleanOption('extensions.logging.enabled', true),
+  new BooleanOption('extensions.update.enabled', false),
+  new BooleanOption('extensions.update.notifyUser', false),
+  new BooleanOption('javascript.enabled', true),
+  new BooleanOption('network.manage-offline-status', false),
+  new IntegerOption('network.http.phishy-userpass-length', 255),
+  new BooleanOption('offline-apps.allow_by_default', true),
+  new BooleanOption('prompts.tab_modal.enabled', false),
+  new BooleanOption('security.csp.enable', false),
+  new IntegerOption('security.fileuri.origin_policy', 3),
+  new BooleanOption('security.fileuri.strict_origin_policy', false),
+  new BooleanOption('security.warn_entering_secure', false),
+  new BooleanOption('security.warn_entering_secure.show_once', false),
+  new BooleanOption('security.warn_entering_weak', false),
+  new BooleanOption('security.warn_entering_weak.show_once', false),
+  new BooleanOption('security.warn_leaving_secure', false),
+  new BooleanOption('security.warn_leaving_secure.show_once', false),
+  new BooleanOption('security.warn_submit_insecure', false),
+  new BooleanOption('security.warn_viewing_mixed', false),
+  new BooleanOption('security.warn_viewing_mixed.show_once', false),
+  new BooleanOption('signon.rememberSignons', false),
+  new BooleanOption('toolkit.networkmanager.disable', true),
+  new IntegerOption('toolkit.telemetry.prompted', 2),
+  new BooleanOption('toolkit.telemetry.enabled', false),
+  new BooleanOption('toolkit.telemetry.rejected', true),
+  new BooleanOption('xpinstall.signatures.required', false),
 ];
 
 /// Default values for 'user.js'.
 final List<PrefsOption> defaultUserPrefs = <PrefsOption>[
-  new BooleanOption("browser.dom.window.dump.enabled", true),
-  new StringOption("browser.newtab.url", "about:blank"),
-  new BooleanOption("browser.newtabpage.enabled", false),
-  new IntegerOption("browser.startup.page", 0),
-  new StringOption("browser.startup.homepage", "about:blank"),
-  new IntegerOption("dom.max_chrome_script_run_time", 30),
-  new IntegerOption("dom.max_script_run_time", 30),
-  new BooleanOption("dom.report_all_js_exceptions", true),
-  new BooleanOption("javascript.options.showInConsole", true),
-  new IntegerOption("network.http.max-connections-per-server", 10),
-  new StringOption("startup.homepage_welcome_url", "about:blank"),
-  new BooleanOption("webdriver_accept_untrusted_certs", true),
-  new BooleanOption("webdriver_assume_untrusted_issuer", true),
+  new BooleanOption('browser.dom.window.dump.enabled', true),
+  new StringOption('browser.newtab.url', 'about:blank'),
+  new BooleanOption('browser.newtabpage.enabled', false),
+  new IntegerOption('browser.startup.page', 0),
+  new StringOption('browser.startup.homepage', 'about:blank'),
+  new IntegerOption('dom.max_chrome_script_run_time', 30),
+  new IntegerOption('dom.max_script_run_time', 30),
+  new BooleanOption('dom.report_all_js_exceptions', true),
+  new BooleanOption('javascript.options.showInConsole', true),
+  new IntegerOption('network.http.max-connections-per-server', 10),
+  new StringOption('startup.homepage_welcome_url', 'about:blank'),
+  new BooleanOption('webdriver_accept_untrusted_certs', true),
+  new BooleanOption('webdriver_assume_untrusted_issuer', true),
 ];
 
 /// Creates a Firefox profile in a format so it can be passed using the
@@ -111,6 +111,7 @@ class FirefoxProfile {
   /// [setOption] and [removeOption] allow to update, add, and remove settings
   /// except these included in [lockedPrefs].
   Set<PrefsOption> _userPrefs = new Set<PrefsOption>();
+
   List<PrefsOption> get userPrefs =>
       new UnmodifiableListView<PrefsOption>(_userPrefs);
 
@@ -254,7 +255,7 @@ class FirefoxProfile {
         new ArchiveFile('user.js', userJsContent.length, userJsContent));
 
     final zipData = new ZipEncoder().encode(archive);
-    return {'firefox_profile': BASE64.encode(zipData)};
+    return {'firefox_profile': base64.encode(zipData)};
   }
 }
 
@@ -271,6 +272,7 @@ abstract class PrefsOption<T> {
 
   final String name;
   T _value;
+
   dynamic get value => _value;
 
   factory PrefsOption(String name, value) {
@@ -313,9 +315,7 @@ abstract class PrefsOption<T> {
         as PrefsOption<T>;
   }
 
-  PrefsOption._(this.name, [this._value]) {
-    assert(name.isNotEmpty);
-  }
+  PrefsOption._(this.name, [this._value]) : assert(name.isNotEmpty);
 
   @override
   bool operator ==(Object other) {
@@ -365,6 +365,7 @@ class StringOption extends PrefsOption<String> {
 
   String _escape(String value) =>
       value.replaceAll(r'\', r'\\').replaceAll('"', r'\"');
+
   @override
   String get _valueAsPrefString {
     return '"${_escape(value)}"';

--- a/lib/support/forwarder.dart
+++ b/lib/support/forwarder.dart
@@ -15,7 +15,7 @@
 library webdriver.support.forwarder;
 
 import 'dart:async' show Future;
-import 'dart:convert' show JSON, UTF8;
+import 'dart:convert' show json, utf8;
 import 'dart:io' show ContentType, Directory, File, HttpRequest, HttpStatus;
 
 import 'package:path/path.dart' as path;
@@ -91,21 +91,21 @@ class WebDriverForwarder {
       }
       Map<String, dynamic> params;
       if (request.method == 'POST') {
-        String requestBody = await UTF8.decodeStream(request);
+        String requestBody = await utf8.decodeStream(request);
         if (requestBody != null && requestBody.isNotEmpty) {
-          params = JSON.decode(requestBody) as Map<String, dynamic>;
+          params = json.decode(requestBody) as Map<String, dynamic>;
         }
       }
       var value = await _forward(request.method, endpoint, params);
       request.response
-          .add(UTF8.encode(JSON.encode({'status': 0, 'value': value})));
+          .add(utf8.encode(json.encode({'status': 0, 'value': value})));
     } on WebDriverException catch (e) {
-      request.response.add(UTF8.encode(JSON.encode({
+      request.response.add(utf8.encode(json.encode({
         'status': e.statusCode,
         'value': {'message': e.message}
       })));
     } catch (e) {
-      request.response.add(UTF8.encode(JSON.encode({
+      request.response.add(utf8.encode(json.encode({
         'status': 13,
         'value': {'message': e.toString()}
       })));

--- a/lib/support/stdio_stepper.dart
+++ b/lib/support/stdio_stepper.dart
@@ -15,8 +15,8 @@
 library webdriver.support.stdio_stepper;
 
 import 'dart:async' show Future, Stream, StreamController;
-import 'dart:convert' show Encoding, JSON;
-import 'dart:io' show exit, Stdin, stdin, SYSTEM_ENCODING;
+import 'dart:convert' show Encoding, json;
+import 'dart:io' show exit, Stdin, stdin, systemEncoding;
 
 import 'package:webdriver/src/async/stepper.dart';
 
@@ -41,7 +41,7 @@ class StdioStepper implements Stepper {
   @override
   Future<bool> step(String method, String command, params) async {
     if (!enabled) return true;
-    print('$method $command(${JSON.encode(params)}):');
+    print('$method $command(${json.encode(params)}):');
     await for (String command in _reader.onLine) {
       switch (command) {
         case 'continue':
@@ -97,7 +97,7 @@ class LineReader {
   /// Only encodings that are a superset of ASCII are supported
   /// TODO(DrMarcII): Support arbitrary encodings
   LineReader(Stream /* <List<int> | int> */ stream,
-      {this.encoding: SYSTEM_ENCODING}) {
+      {this.encoding: systemEncoding}) {
     if (stream is Stdin) {
       stdin.lineMode = false;
     }

--- a/test/async_alert_test.dart
+++ b/test/async_alert_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.alert_test;
 
 import 'package:test/test.dart';

--- a/test/async_command_event_test.dart
+++ b/test/async_command_event_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.command_event_test;
 
 import 'package:stack_trace/stack_trace.dart';
@@ -51,10 +51,10 @@ void main() {
       await waitFor(() => events, matcher: hasLength(2));
       expect(events[1].method, 'GET');
       expect(events[1].endPoint, contains('alert'));
-      expect(events[1].exception, new isInstanceOf<WebDriverException>());
+      expect(events[1].exception, const isInstanceOf<WebDriverException>());
       expect(events[1].result, isNull);
       expect(events[1].startTime.isBefore(events[1].endTime), isTrue);
-      expect(events[1].stackTrace, new isInstanceOf<Chain>());
+      expect(events[1].stackTrace, const isInstanceOf<Chain>());
     });
 
     test('handles normal operation', () async {
@@ -65,7 +65,7 @@ void main() {
       expect(events[1].exception, isNull);
       expect(events[1].result, hasLength(0));
       expect(events[1].startTime.isBefore(events[1].endTime), isTrue);
-      expect(events[1].stackTrace, new isInstanceOf<Chain>());
+      expect(events[1].stackTrace, const isInstanceOf<Chain>());
     });
   }, testOn: '!js');
 }

--- a/test/async_keyboard_test.dart
+++ b/test/async_keyboard_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.keyboard_test;
 
 import 'dart:io';

--- a/test/async_logs_test.dart
+++ b/test/async_logs_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.logs_test;
 
 import 'package:test/test.dart';

--- a/test/async_mouse_test.dart
+++ b/test/async_mouse_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.mouse_test;
 
 import 'package:test/test.dart';

--- a/test/async_navigation_test.dart
+++ b/test/async_navigation_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.navigation_test;
 
 import 'package:test/test.dart';

--- a/test/async_options_test.dart
+++ b/test/async_options_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.options_test;
 
 import 'package:test/test.dart';

--- a/test/async_target_locator_test.dart
+++ b/test/async_target_locator_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.target_locator_test;
 
 import 'package:test/test.dart';

--- a/test/async_web_driver_test.dart
+++ b/test/async_web_driver_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.web_driver_test;
 
 import 'dart:async';
@@ -136,7 +136,7 @@ void main() {
       test('windows', () async {
         var windows = await driver.windows.toList();
         expect(windows, hasLength(isPositive));
-        expect(windows, everyElement(new isInstanceOf<Window>()));
+        expect(windows, everyElement(const isInstanceOf<Window>()));
       });
 
       test('execute', () async {
@@ -162,19 +162,19 @@ void main() {
       test('captureScreenshot', () async {
         var screenshot = await driver.captureScreenshot().toList();
         expect(screenshot, hasLength(isPositive));
-        expect(screenshot, everyElement(new isInstanceOf<int>()));
+        expect(screenshot, everyElement(const isInstanceOf<int>()));
       });
 
       test('captureScreenshotAsList', () async {
         var screenshot = await driver.captureScreenshotAsList();
         expect(screenshot, hasLength(isPositive));
-        expect(screenshot, everyElement(new isInstanceOf<int>()));
+        expect(screenshot, everyElement(const isInstanceOf<int>()));
       });
 
       test('captureScreenshotAsBase64', () async {
         var screenshot = await driver.captureScreenshotAsBase64();
         expect(screenshot, hasLength(isPositive));
-        expect(screenshot, new isInstanceOf<String>());
+        expect(screenshot, const isInstanceOf<String>());
       });
 
       test('future based event listeners work with script timeouts', () async {
@@ -184,7 +184,7 @@ void main() {
         });
 
         try {
-          driver.timeouts.setScriptTimeout(const Duration(seconds: 1));
+          await driver.timeouts.setScriptTimeout(const Duration(seconds: 1));
           await driver.executeAsync('', []);
           fail('Did not throw timeout as expected');
         } catch (e) {

--- a/test/async_web_driver_test.dart
+++ b/test/async_web_driver_test.dart
@@ -184,7 +184,7 @@ void main() {
         });
 
         try {
-          await driver.timeouts.setScriptTimeout(const Duration(seconds: 1));
+          driver.timeouts.setScriptTimeout(const Duration(seconds: 1));
           await driver.executeAsync('', []);
           fail('Did not throw timeout as expected');
         } catch (e) {

--- a/test/async_web_element_test.dart
+++ b/test/async_web_element_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.web_element_test;
 
 import 'package:test/test.dart';

--- a/test/async_window_test.dart
+++ b/test/async_window_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.window_test;
 
 import 'dart:math' show Point, Rectangle;

--- a/test/support/async_test.dart
+++ b/test/support/async_test.dart
@@ -43,7 +43,7 @@ void main() {
       var lock = new Lock();
       var secondLockAcquired = false;
       await lock.acquire();
-      await lock.acquire().then((_) => secondLockAcquired = true);
+      lock.acquire().then((_) => secondLockAcquired = true);
       // Make sure that lock is not unacquired just because of timing
       await new Future.delayed(const Duration(seconds: 1));
       expect(secondLockAcquired, isFalse);

--- a/test/support/async_test.dart
+++ b/test/support/async_test.dart
@@ -36,14 +36,14 @@ void main() {
 
     test('release without acquiring fails', () {
       var lock = new Lock();
-      expect(() => lock.release(), throwsA(new isInstanceOf<StateError>()));
+      expect(() => lock.release(), throwsA(const isInstanceOf<StateError>()));
     });
 
     test('locking prevents acquisition of lock', () async {
       var lock = new Lock();
       var secondLockAcquired = false;
       await lock.acquire();
-      lock.acquire().then((_) => secondLockAcquired = true);
+      await lock.acquire().then((_) => secondLockAcquired = true);
       // Make sure that lock is not unacquired just because of timing
       await new Future.delayed(const Duration(seconds: 1));
       expect(secondLockAcquired, isFalse);
@@ -166,7 +166,7 @@ void main() {
     });
 
     test('sanity test with real Clock -- successful', () async {
-      var clock = new Clock();
+      var clock = const Clock();
       var count = 0;
       var result = await clock.waitFor(() {
         if (count < 2) {
@@ -180,7 +180,7 @@ void main() {
     });
 
     test('sanity test with real Clock -- throws', () async {
-      var clock = new Clock();
+      var clock = const Clock();
       var exception;
       try {
         await clock.waitFor(() => throw 'an exception');
@@ -191,7 +191,7 @@ void main() {
     });
 
     test('sanity test with real Clock -- never matches', () async {
-      var clock = new Clock();
+      var clock = const Clock();
       var exception;
       try {
         await clock.waitFor(() => null, matcher: isNotNull);

--- a/test/support/firefox_profile_test.dart
+++ b/test/support/firefox_profile_test.dart
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.support.firefox_profile_test;
 
-import 'dart:convert' show BASE64, Encoding, UTF8;
+import 'dart:convert' show base64, Encoding, utf8;
 import 'dart:io' as io;
 
 import 'package:archive/archive.dart' show Archive, ArchiveFile, ZipDecoder;
@@ -32,7 +32,7 @@ void main() {
           r'extensions/{972ce4c6-7e08-4474-a285-3208198ce6fd}\",\"e\":true,\'
           r'"v\":\"40.0\",\"st\":1439535413000,\"mt\":1438968709000}}}");';
       var option = new PrefsOption.parse(value);
-      expect(option, new isInstanceOf<StringOption>());
+      expect(option, const isInstanceOf<StringOption>());
       expect(option.asPrefString, value);
     });
 
@@ -40,21 +40,21 @@ void main() {
       const value = r'user_pref("browser.cache.disk.parent_directory", '
           r'"\\\\volume\\web\\cache\\mz");';
       var option = new PrefsOption.parse(value);
-      expect(option, new isInstanceOf<StringOption>());
+      expect(option, const isInstanceOf<StringOption>());
       expect(option.asPrefString, value);
     });
 
     test('parse and serialize integer value', () {
       const value = r'user_pref("browser.cache.frecency_experiment", 3);';
       var option = new PrefsOption.parse(value);
-      expect(option, new isInstanceOf<IntegerOption>());
+      expect(option, const isInstanceOf<IntegerOption>());
       expect(option.asPrefString, value);
     });
 
     test('parse and serialize negative integer value', () {
       const value = r'user_pref("browser.cache.frecency_experiment", -3);';
       var option = new PrefsOption.parse(value);
-      expect(option, new isInstanceOf<IntegerOption>());
+      expect(option, const isInstanceOf<IntegerOption>());
       expect(option.asPrefString, value);
     });
 
@@ -62,7 +62,7 @@ void main() {
       const value =
           r'user_pref("browser.cache.disk.smart_size.first_run", true);';
       var option = new PrefsOption.parse(value);
-      expect(option, new isInstanceOf<BooleanOption>());
+      expect(option, const isInstanceOf<BooleanOption>());
       expect(option.asPrefString, value);
     });
 
@@ -70,7 +70,7 @@ void main() {
       const value =
           r'user_pref("browser.cache.disk.smart_size.first_run", false);';
       var option = new PrefsOption.parse(value);
-      expect(option, new isInstanceOf<BooleanOption>());
+      expect(option, const isInstanceOf<BooleanOption>());
       expect(option.asPrefString, value);
     });
 
@@ -78,7 +78,7 @@ void main() {
       const value =
           r'user_pref("browser.cache.disk.smart_size.first_run", True);';
       var option = new PrefsOption.parse(value);
-      expect(option, new isInstanceOf<BooleanOption>());
+      expect(option, const isInstanceOf<BooleanOption>());
       expect(option.value, true);
     });
 
@@ -173,7 +173,7 @@ void main() {
 }
 
 Archive unpackArchiveData(Map profileData) {
-  var zipArchive = BASE64.decode(profileData['firefox_profile']);
+  var zipArchive = base64.decode(profileData['firefox_profile']);
   return new ZipDecoder().decodeBytes(zipArchive, verify: true);
 }
 
@@ -184,7 +184,7 @@ class MockFile implements io.File {
   MockFile(this.content);
 
   @override
-  String readAsStringSync({Encoding encoding: UTF8}) => content;
+  String readAsStringSync({Encoding encoding: utf8}) => content;
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/support/forwarder_test.dart
+++ b/test/support/forwarder_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.support.forwarder_test;
 
 import 'dart:io';
@@ -40,7 +40,7 @@ void main() {
       forwarder =
           new WebDriverForwarder(driver, prefix: '/webdriver/session/1');
 
-      server = await HttpServer.bind(InternetAddress.ANY_IP_V4, 0);
+      server = await HttpServer.bind(InternetAddress.anyIPv4, 0);
       server.listen((request) {
         if (request.uri.path.startsWith('/webdriver')) {
           forwarder.forward(request);

--- a/test/sync/alert.dart
+++ b/test/sync/alert.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.alert_test;
 
 import 'package:test/test.dart';

--- a/test/sync/command_event.dart
+++ b/test/sync/command_event.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.command_event_test;
 
 import 'package:stack_trace/stack_trace.dart';
@@ -46,10 +46,10 @@ void runTests(config.createTestDriver createTestDriver) {
       } catch (NoSuchAlertException) {}
       expect(events[1].method, 'GET');
       expect(events[1].endPoint, contains('alert'));
-      expect(events[1].exception, new isInstanceOf<WebDriverException>());
+      expect(events[1].exception, const isInstanceOf<WebDriverException>());
       expect(events[1].result, isNull);
       expect(events[1].startTime.isBefore(events[1].endTime), isTrue);
-      expect(events[1].stackTrace, new isInstanceOf<Chain>());
+      expect(events[1].stackTrace, const isInstanceOf<Chain>());
     });
 
     test('handles normal operation', () {
@@ -59,7 +59,7 @@ void runTests(config.createTestDriver createTestDriver) {
       expect(events[1].exception, isNull);
       expect(events[1].result, hasLength(0));
       expect(events[1].startTime.isBefore(events[1].endTime), isTrue);
-      expect(events[1].stackTrace, new isInstanceOf<Chain>());
+      expect(events[1].stackTrace, const isInstanceOf<Chain>());
     });
   }, timeout: const Timeout(const Duration(minutes: 2)));
 }

--- a/test/sync/cookies.dart
+++ b/test/sync/cookies.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.options_test;
 
 import 'package:test/test.dart';

--- a/test/sync/keyboard.dart
+++ b/test/sync/keyboard.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.keyboard_test;
 
 import 'dart:io';

--- a/test/sync/logs.dart
+++ b/test/sync/logs.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.logs_test;
 
 import 'package:test/test.dart';

--- a/test/sync/mouse.dart
+++ b/test/sync/mouse.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.mouse_test;
 
 import 'package:test/test.dart';

--- a/test/sync/navigation.dart
+++ b/test/sync/navigation.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.navigation_test;
 
 import 'package:test/test.dart';

--- a/test/sync/spec_inference_test.dart
+++ b/test/sync/spec_inference_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.spec_inference_test;
 
 import 'package:test/test.dart';
@@ -43,7 +43,7 @@ void main() {
         button.findElement(const By.tagName('tr'));
         throw 'Expected NoSuchElementException';
       } catch (e) {
-        expect(e, new isInstanceOf<json.NoSuchElementException>());
+        expect(e, const isInstanceOf<json.NoSuchElementException>());
         expect(e.toString(), contains('Unable to locate element'));
       }
     });
@@ -56,7 +56,7 @@ void main() {
         button.findElement(const By.tagName('tr'));
         throw 'Expected W3cWebDriverException';
       } catch (e) {
-        expect(e, new isInstanceOf<w3c.W3cWebDriverException>());
+        expect(e, const isInstanceOf<w3c.W3cWebDriverException>());
         expect(e.toString(), contains('Unable to locate element'));
       }
     });

--- a/test/sync/sync_async_interop.dart
+++ b/test/sync/sync_async_interop.dart
@@ -37,27 +37,27 @@ void runTests(config.createTestDriver createTestDriver) {
 
     test('sync to async driver works', () async {
       final asyncDriver = driver.asyncDriver;
-      expect(asyncDriver, new isInstanceOf<async_core.WebDriver>());
+      expect(asyncDriver, const isInstanceOf<async_core.WebDriver>());
       await asyncDriver.get(config.testPagePath);
       driver.findElement(const By.tagName('button'));
     });
 
     test('sync to async web element works', () async {
       final asyncDriver = driver.asyncDriver;
-      expect(asyncDriver, new isInstanceOf<async_core.WebDriver>());
+      expect(asyncDriver, const isInstanceOf<async_core.WebDriver>());
       await asyncDriver.get(config.testPagePath);
       final button = driver.findElement(const By.tagName('button'));
       final asyncButton = button.asyncElement;
 
-      expect(button, new isInstanceOf<WebElement>());
-      expect(asyncButton, new isInstanceOf<async_core.WebElement>());
+      expect(button, const isInstanceOf<WebElement>());
+      expect(asyncButton, const isInstanceOf<async_core.WebElement>());
       expect(asyncButton.id, button.id);
       expect(await asyncButton.name, button.name);
     });
 
     test('sync to async web element finding works', () async {
       final asyncDriver = driver.asyncDriver;
-      expect(asyncDriver, new isInstanceOf<async_core.WebDriver>());
+      expect(asyncDriver, const isInstanceOf<async_core.WebDriver>());
       await asyncDriver.get(config.testPagePath);
 
       final table = driver.findElement(const By.tagName('table'));

--- a/test/sync/target_locator.dart
+++ b/test/sync/target_locator.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.target_locator_test;
 
 import 'package:test/test.dart';

--- a/test/sync/timeouts.dart
+++ b/test/sync/timeouts.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.options_test;
 
 import 'package:test/test.dart';

--- a/test/sync/w3c_web_element.dart
+++ b/test/sync/w3c_web_element.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.web_element_test;
 
 import 'dart:io';
@@ -135,7 +135,7 @@ void runTests(config.createTestDriver createTestDriver) {
         button.findElement(const By.tagName('tr'));
         throw 'Expected Exception';
       } catch (e) {
-        expect(e, new isInstanceOf<W3cWebDriverException>());
+        expect(e, const isInstanceOf<W3cWebDriverException>());
         expect((e as W3cWebDriverException).httpStatusCode, 404);
         expect((e as W3cWebDriverException).error, 'no such element');
         expect((e as W3cWebDriverException).message,

--- a/test/sync/web_driver.dart
+++ b/test/sync/web_driver.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.web_driver_test;
 
 import 'dart:io';
@@ -133,7 +133,7 @@ void runTests(config.createTestDriver createTestDriver) {
       test('windows', () {
         var windows = driver.windows.toList();
         expect(windows, hasLength(isPositive));
-        expect(windows, everyElement(new isInstanceOf<Window>()));
+        expect(windows, everyElement(const isInstanceOf<Window>()));
       });
 
       test('execute', () {
@@ -157,19 +157,19 @@ void runTests(config.createTestDriver createTestDriver) {
       test('captureScreenshot', () {
         var screenshot = driver.captureScreenshotAsList().toList();
         expect(screenshot, hasLength(isPositive));
-        expect(screenshot, everyElement(new isInstanceOf<int>()));
+        expect(screenshot, everyElement(const isInstanceOf<int>()));
       });
 
       test('captureScreenshotAsList', () {
         var screenshot = driver.captureScreenshotAsList();
         expect(screenshot, hasLength(isPositive));
-        expect(screenshot, everyElement(new isInstanceOf<int>()));
+        expect(screenshot, everyElement(const isInstanceOf<int>()));
       });
 
       test('captureScreenshotAsBase64', () {
         var screenshot = driver.captureScreenshotAsBase64();
         expect(screenshot, hasLength(isPositive));
-        expect(screenshot, new isInstanceOf<String>());
+        expect(screenshot, const isInstanceOf<String>());
       });
 
       test('event listeners work with script timeouts', () {

--- a/test/sync/web_element.dart
+++ b/test/sync/web_element.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.web_element_test;
 
 import 'package:test/test.dart';
@@ -148,7 +148,7 @@ void runTests(config.createTestDriver createTestDriver) {
         button.findElement(const By.tagName('tr'));
         throw 'Expected NoSuchElementException';
       } catch (e) {
-        expect(e, new isInstanceOf<NoSuchElementException>());
+        expect(e, const isInstanceOf<NoSuchElementException>());
       }
     });
 

--- a/test/sync/window.dart
+++ b/test/sync/window.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn("vm")
+@TestOn('vm')
 library webdriver.window_test;
 
 import 'dart:math' show Rectangle;

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -22,10 +22,10 @@ import 'package:path/path.dart' as path;
 import 'package:webdriver/async_core.dart' as async_core;
 import 'package:webdriver/sync_core.dart' as sync_core;
 
-final Matcher isWebElement = new isInstanceOf<async_core.WebElement>();
-final Matcher isSyncWebElement = new isInstanceOf<sync_core.WebElement>();
-final Matcher isRectangle = new isInstanceOf<Rectangle<int>>();
-final Matcher isPoint = new isInstanceOf<Point<int>>();
+final Matcher isWebElement = const isInstanceOf<async_core.WebElement>();
+final Matcher isSyncWebElement = const isInstanceOf<sync_core.WebElement>();
+final Matcher isRectangle = const isInstanceOf<Rectangle<int>>();
+final Matcher isPoint = const isInstanceOf<Point<int>>();
 
 String get testPagePath {
   String testPagePath = path.absolute('test', 'test_page.html');


### PR DESCRIPTION
Mainly the following types:

1) double-quote -> single-quote
2) new Map -> map literal
3) Don't check null in == operator
4) Fix deprecated `convert` members. For example: BASE64 -> base64
5) Put assert to initializer list in constructor
6) Await futures in async functions