### PR TITLE
Bring in PageLoader's property retrieval logic for json wire format

### DIFF
--- a/lib/src/sync/common.dart
+++ b/lib/src/sync/common.dart
@@ -36,12 +36,16 @@ async_core.WebElement createAsyncWebElement(WebElement element) =>
 
 /// Simple class to provide access to indexed properties such as WebElement
 /// attributes or css styles.
-class Attributes {
+abstract class Attributes {
+  String operator [](String name);
+}
+
+class SimpleAttributes extends Attributes {
   final Resolver _resolver;
 
-  Attributes(driver, command) : _resolver = new Resolver(driver, command);
+  SimpleAttributes(driver, command) : _resolver = new Resolver(driver, command);
 
-  String operator [](String name) => _resolver.get(name) as String;
+  String operator [](String name) => _resolver.get(name)?.toString();
 }
 
 abstract class SearchContext {

--- a/lib/src/sync/w3c_spec/web_element.dart
+++ b/lib/src/sync/w3c_spec/web_element.dart
@@ -109,14 +109,15 @@ class W3cWebElement implements WebElement, SearchContext {
 
   @override
   Attributes get attributes =>
-      new Attributes(driver, '$_elementPrefix/attribute');
+      new SimpleAttributes(driver, '$_elementPrefix/attribute');
 
   @override
   Attributes get properties =>
-      new Attributes(driver, '$_elementPrefix/property');
+      new SimpleAttributes(driver, '$_elementPrefix/property');
 
   @override
-  Attributes get cssProperties => new Attributes(driver, '$_elementPrefix/css');
+  Attributes get cssProperties =>
+      new SimpleAttributes(driver, '$_elementPrefix/css');
 
   @override
   bool equals(WebElement other) =>

--- a/lib/src/sync/w3c_spec/window.dart
+++ b/lib/src/sync/w3c_spec/window.dart
@@ -45,22 +45,18 @@ class W3cWindow implements Window {
       : _windowResolver = new Resolver(_driver, 'window'),
         _session = new Resolver(_driver, '');
 
-  // TODO(staats): better exceptions.
   @override
-  Rectangle<int> get size =>
-      throw 'Unsupported by W3C spec, use "rect" instead.';
+  Rectangle<int> get size => rect;
 
   @override
-  Point<int> get location =>
-      throw 'Unsupported by W3C spec, use "rect" instead.';
+  Point<int> get location => rect.topLeft;
 
   @override
-  void setSize(Rectangle<int> size) =>
-      throw 'Unsupported by W3C spec, use "rect" instead.';
+  void setSize(Rectangle<int> size) => rect = size;
 
   @override
   void setLocation(Point<int> point) =>
-      throw 'Unsupported by W3C spec, use "rect" instead.';
+      rect = new Rectangle(point.x, point.y, rect.width, rect.height);
 
   @override
   Rectangle<int> get rect {

--- a/lib/src/sync/window.dart
+++ b/lib/src/sync/window.dart
@@ -28,11 +28,9 @@ abstract class Windows {
 /// Upon use, the window will automatically be set as active.
 abstract class Window {
   /// The size of the window.
-  @Deprecated('JSON wire legacy support, unsupported for newer browsers')
   Rectangle<int> get size;
 
   /// The location of the window.
-  @Deprecated('JSON wire legacy support, unsupported for newer browsers')
   Point<int> get location;
 
   /// The location and size of the window.
@@ -45,11 +43,9 @@ abstract class Window {
   void maximize();
 
   /// Set the window size.
-  @Deprecated('JSON wire legacy support, unsupported for newer browsers')
   void setSize(Rectangle<int> size);
 
   /// Set the window location.
-  @Deprecated('JSON wire legacy support, unsupported for newer browsers')
   void setLocation(Point<int> point);
 
   /// Sets the window as active.

--- a/test/sync/keyboard.dart
+++ b/test/sync/keyboard.dart
@@ -50,37 +50,28 @@ void runTests(config.createTestDriver createTestDriver) {
 
     test('sendKeys -- once', () {
       driver.keyboard.sendKeys('abcdef');
-      expect(valueOf(textInput), 'abcdef');
+      expect(textInput.properties['value'], 'abcdef');
     });
 
     test('sendKeys -- twice', () {
       driver.keyboard.sendKeys('abc');
       driver.keyboard.sendKeys('def');
-      expect(valueOf(textInput), 'abcdef');
+      expect(textInput.properties['value'], 'abcdef');
     });
 
     test('sendKeys -- with tab', () {
       driver.keyboard.sendKeys('abc${Keyboard.tab}def');
-      expect(valueOf(textInput), 'abc');
+      expect(textInput.properties['value'], 'abc');
     });
 
     // NOTE: does not work on Mac.
     test('sendChord -- CTRL+X', () {
       driver.keyboard.sendKeys('abcdef');
-      expect(valueOf(textInput), 'abcdef');
+      expect(textInput.properties['value'], 'abcdef');
       driver.keyboard.sendChord([ctrlCmdKey, 'a']);
       driver.keyboard.sendChord([ctrlCmdKey, 'x']);
       driver.keyboard.sendKeys('xxx');
-      expect(valueOf(textInput), 'xxx');
+      expect(textInput.properties['value'], 'xxx');
     });
   }, timeout: const Timeout(const Duration(minutes: 2)));
-}
-
-/// Gets the "value" property of a [WebElement].
-///
-/// The behavior for the "value" property of a text input is different for
-/// different specs (json wire updates it through attribute and W3C updates it
-/// through property).
-String valueOf(WebElement textInput) {
-  return textInput.attributes['value'] ?? textInput.properties['value'];
 }

--- a/test/sync/web_element.dart
+++ b/test/sync/web_element.dart
@@ -68,13 +68,13 @@ void runTests(config.createTestDriver createTestDriver) {
 
     test('sendKeys', () {
       textInput.sendKeys('some keys');
-      expect(textInput.attributes['value'], 'some keys');
+      expect(textInput.properties['value'], 'some keys');
     });
 
     test('clear', () {
       textInput.sendKeys('some keys');
       textInput.clear();
-      expect(textInput.attributes['value'], '');
+      expect(textInput.properties['value'], '');
     });
 
     test('enabled', () {
@@ -174,12 +174,14 @@ void runTests(config.createTestDriver createTestDriver) {
       expect(table.attributes['id'], 'table1');
       expect(table.attributes['non-standard'], 'a non standard attr');
       expect(table.attributes['disabled'], isNull);
-      expect(disabled.attributes['disabled'], 'true');
+      expect(disabled.attributes['disabled'], isNotNull);
     });
 
     test('cssProperties', () {
       expect(invisible.cssProperties['display'], 'none');
-      expect(invisible.cssProperties['background-color'], 'rgba(255, 0, 0, 1)');
+      final backgroundColor = invisible.cssProperties['background-color'];
+      expect(backgroundColor, contains('255, 0, 0'));
+      expect(backgroundColor, startsWith('rgb'));
       expect(invisible.cssProperties['direction'], 'ltr');
     });
 


### PR DESCRIPTION
1. Moved PageLoader's property retrieval logic to json wire's specific webdriver (W3C will keep the current correct logic).
   - This will help when we update the PageLoader project to use different property retrieval logic in json wire and W3C.

2. Implemented old Window interface in W3C for compatibility.
   - Minor compatibility enhancement.