### PR TITLE
Drop support for pkg:unittest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0
+
+* Dropped support for `pkg:unittest`.
+
 ## v2.0.0-beta
 Initial beta release of WebDriver 2.0. Many changes exist here, and 
 as the release evolves there may be breaking changes to the API. 

--- a/lib/support/async.dart
+++ b/lib/support/async.dart
@@ -18,7 +18,6 @@ import 'dart:async' show Completer, Future, FutureOr;
 
 import 'package:matcher/matcher.dart' as m;
 import 'package:stack_trace/stack_trace.dart' show Chain;
-import 'package:unittest/unittest.dart' as ut;
 
 const defaultInterval = const Duration(milliseconds: 500);
 const defaultTimeout = const Duration(seconds: 5);
@@ -54,7 +53,7 @@ class Clock {
       {matcher,
       Duration timeout: defaultTimeout,
       Duration interval: defaultInterval}) async {
-    if (matcher != null && matcher is! ut.Matcher && matcher is! m.Matcher) {
+    if (matcher != null && matcher is! m.Matcher) {
       matcher = m.equals(matcher);
     }
 
@@ -64,8 +63,6 @@ class Clock {
         var value = await condition();
         if (matcher is m.Matcher) {
           _matcherExpect(value, matcher);
-        } else if (matcher is ut.Matcher) {
-          _unittestExpect(value, matcher);
         }
         return value;
       } catch (e) {
@@ -78,8 +75,6 @@ class Clock {
     }
   }
 }
-
-void _unittestExpect(value, ut.Matcher matcher) => ut.expect(value, matcher);
 
 void _matcherExpect(value, m.Matcher matcher) {
   var matchState = {};

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdriver
-version: 2.0.0-beta
+version: 2.0.0-dev
 authors:
   - Marc Fisher II <fisherii@google.com>
   - Matt Staats<staats@google.com>
@@ -15,6 +15,5 @@ dependencies:
   path: '^1.3.0'
   stack_trace: '^1.3.0'
   sync_http: "^0.1.1"
-  unittest: '^0.11.6'
 dev_dependencies:
   test: '^0.12.3'

--- a/test/support/async_test.dart
+++ b/test/support/async_test.dart
@@ -17,7 +17,6 @@ library webdriver.support.async_test;
 import 'dart:async' show Future;
 
 import 'package:test/test.dart';
-import 'package:unittest/unittest.dart' as ut;
 import 'package:webdriver/support/async.dart';
 
 void main() {
@@ -126,26 +125,6 @@ void main() {
         exception = e;
       }
       expect(exception, isNotNull);
-    });
-
-    test('throws if condition never matches unittest.Matcher', () async {
-      var exception;
-      try {
-        await clock.waitFor(() => null, matcher: ut.isNotNull);
-      } catch (e) {
-        exception = e;
-      }
-      expect(exception, isNotNull);
-    });
-
-    test('returns if condition matches unittest.Matcher', () async {
-      var count = 0;
-      var result = await clock.waitFor(() {
-        if (count == 2) return 'Google';
-        count++;
-        return null;
-      }, matcher: ut.isNotNull);
-      expect(result, isNotNull);
     });
 
     test('uses Future value', () async {


### PR DESCRIPTION
pkg:unittest is not supported in Dart 2

Fixes https://github.com/google/webdriver.dart/issues/197