### PR TITLE
Remove use of deprecated `retype`.

### DIFF
--- a/lib/src/sync/json_wire_spec/window.dart
+++ b/lib/src/sync/json_wire_spec/window.dart
@@ -30,7 +30,7 @@ class JsonWireWindows implements Windows {
 
   @override
   List<Window> get allWindows =>
-      (_resolver.get('window_handles').retype<String>())
+      (_resolver.get('window_handles').cast<String>())
           .map<Window>((handle) => new JsonWireWindow(_driver, handle))
           .toList();
 }


### PR DESCRIPTION
The method is removed in .dev.62, so this package should no longer use it.