### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/test/configs/async_io_config.dart
+++ b/test/configs/async_io_config.dart
@@ -50,7 +50,7 @@ Future<HttpServer> createTestServerAndGoToTestPage(WebDriver driver) async {
         request.response
           ..statusCode = HttpStatus.ok
           ..headers.set('Content-type', 'text/html');
-        file.openRead().pipe(request.response);
+        file.openRead().cast<List<int>>().pipe(request.response);
       } else {
         request.response
           ..statusCode = HttpStatus.notFound

--- a/test/configs/sync_io_config.dart
+++ b/test/configs/sync_io_config.dart
@@ -47,7 +47,7 @@ Future<HttpServer> createTestServerAndGoToTestPage(WebDriver driver) async {
         request.response
           ..statusCode = HttpStatus.ok
           ..headers.set('Content-type', 'text/html');
-        file.openRead().pipe(request.response);
+        file.openRead().cast<List<int>>().pipe(request.response);
       } else {
         request.response
           ..statusCode = HttpStatus.notFound


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

dart-lang/sdk#36900