### PR TITLE
Fix per breaking change to HttpRequest and HttpClientResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
+## v2.1.0+1
+
+* Forward-compatible fix for upcoming Dart SDK breaking change
+  (`HttpClientResponse` implementing `Stream<Uint8List>`)
+
 ## v2.1.0
+
 * Full support of JsonWire and W3C protocol specs in sync and async WebDriver.
 
 ## v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v2.1.0+1
+## v2.1.1
 
 * Forward-compatible fix for upcoming Dart SDK breaking change
   (`HttpClientResponse` implementing `Stream<Uint8List>`)

--- a/lib/src/request/async_io_request_client.dart
+++ b/lib/src/request/async_io_request_client.dart
@@ -49,7 +49,7 @@ class AsyncIoRequestClient extends AsyncRequestClient {
       final response = await httpRequest.close();
 
       return WebDriverResponse(response.statusCode, response.reasonPhrase,
-          await utf8.decodeStream(response));
+          await utf8.decodeStream(response.cast<List<int>>()));
     } finally {
       _lock.release();
     }

--- a/lib/support/forwarder.dart
+++ b/lib/support/forwarder.dart
@@ -90,7 +90,7 @@ class WebDriverForwarder {
       }
       Map<dynamic, dynamic> params;
       if (request.method == 'POST') {
-        String requestBody = await utf8.decodeStream(request);
+        String requestBody = await utf8.decodeStream(request.cast<List<int>>());
         if (requestBody != null && requestBody.isNotEmpty) {
           params = json.decode(requestBody) as Map<dynamic, dynamic>;
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdriver
-version: 2.1.0
+version: 2.1.0+1
 authors:
   - Marc Fisher II <fisherii@google.com>
   - Matt Staats<staats@google.com>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdriver
-version: 2.1.0+1
+version: 2.1.1
 authors:
   - Marc Fisher II <fisherii@google.com>
   - Matt Staats<staats@google.com>


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

dart-lang/sdk#36900