### PR TITLE
Update versions and perform small cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.1.2
+
+* Updated to latest version of sync_http.
+
 ## v2.1.1
 
 * Forward-compatible fix for upcoming Dart SDK breaking change

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,3 @@
-analyzer:
-  strong-mode: true
 linter:
   rules:
     - always_declare_return_types
@@ -12,7 +10,6 @@ linter:
     - await_only_futures
     - cancel_subscriptions
     - control_flow_in_finally
-    - empty_constructor_bodies
     - empty_constructor_bodies
     - empty_statements
     - hash_and_equals
@@ -43,8 +40,6 @@ linter:
     - prefer_typing_uninitialized_variables
     - recursive_getters
     - slash_for_doc_comments
-    - slash_for_doc_comments
-    - super_goes_last
     - test_types_in_equals
     - throw_in_finally
     - type_init_formals

--- a/lib/async_core.dart
+++ b/lib/async_core.dart
@@ -124,5 +124,5 @@ WebDriver fromExistingSessionSync(
   }
 
   return WebDriver(uri, sessionId, UnmodifiableMapView(capabilities),
-      createRequestClient(uri.resolve('session/${sessionId}/')), spec);
+      createRequestClient(uri.resolve('session/$sessionId/')), spec);
 }

--- a/lib/src/async/common.dart
+++ b/lib/src/async/common.dart
@@ -23,7 +23,7 @@ typedef GetAttribute = Future<String> Function(String name);
 /// Simple class to provide access to indexed properties such as WebElement
 /// attributes or css styles.
 class Attributes {
-  GetAttribute _getAttribute;
+  final GetAttribute _getAttribute;
 
   Attributes(this._getAttribute);
 

--- a/lib/src/handler/json_wire_handler.dart
+++ b/lib/src/handler/json_wire_handler.dart
@@ -69,5 +69,5 @@ class JsonWireWebDriverHandler extends WebDriverHandler {
       deserialize(parseJsonWireResponse(response), createElement);
 
   @override
-  String toString() => "JsonWire";
+  String toString() => 'JsonWire';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
   matcher: ^0.12.3
   path: ^1.3.0
   stack_trace: ^1.3.0
-  sync_http: ^0.2.0
+  sync_http: '>=0.1.1 <0.3.0'
 dev_dependencies:
   test: '^1.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdriver
-version: 2.1.1
+version: 2.1.2
 authors:
   - Marc Fisher II <fisherii@google.com>
   - Matt Staats<staats@google.com>
@@ -15,6 +15,6 @@ dependencies:
   matcher: ^0.12.3
   path: ^1.3.0
   stack_trace: ^1.3.0
-  sync_http: ^0.1.1
+  sync_http: ^0.2.0
 dev_dependencies:
   test: '^1.0.0'


### PR DESCRIPTION
We need to bump the version of sync_http to pick up the breaking http client change. Also removed some duplicate and deprecated lints