### PR TITLE
Widen constraint on package:sync_http to allow 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.1.2
+
+* Widen constraint on `package:sync_http` in `pubspec.yaml`.
+
 ## v2.1.1
 
 * Forward-compatible fix for upcoming Dart SDK breaking change

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdriver
-version: 2.1.1
+version: 2.1.2
 authors:
   - Marc Fisher II <fisherii@google.com>
   - Matt Staats<staats@google.com>
@@ -15,6 +15,6 @@ dependencies:
   matcher: ^0.12.3
   path: ^1.3.0
   stack_trace: ^1.3.0
-  sync_http: ^0.1.1
+  sync_http: '>= 0.1.1 <0.3.0'
 dev_dependencies:
   test: '^1.0.0'


### PR DESCRIPTION
Flutter needs to use version 0.2.0 of package:sync_http in order to
allow the new Dart SDK (which contains a breaking change, see [0]).

[0] https://dart-review.googlesource.com/c/sdk/+/135357