### PR TITLE
Make the `waitFor` utilities return `Future<T>` instead of `Future<T?>`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.1-dev
 
-* Return non-nullable `T` from `waitFor`.
+* Return Future with non-nullable generic from `waitFor`. The generic `T` may
+  still be a nullable type where required.
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.0.1-dev
 
+* Return non-nullable `T` from `waitFor`.
+
 ## 3.0.0
 
 * Stable release for null safety.

--- a/lib/support/async.dart
+++ b/lib/support/async.dart
@@ -24,7 +24,7 @@ const defaultTimeout = Duration(seconds: 5);
 
 const clock = Clock();
 
-Future<T?> waitFor<T>(FutureOr<T> Function() condition,
+Future<T> waitFor<T>(FutureOr<T> Function() condition,
         {matcher,
         Duration timeout = defaultTimeout,
         Duration interval = defaultInterval}) =>
@@ -49,7 +49,7 @@ class Clock {
   /// is returned. Otherwise, if [condition] throws, then that exception is
   /// rethrown. If [condition] doesn't throw then an [expect] exception is
   /// thrown.
-  Future<T?> waitFor<T>(FutureOr<T>? Function() condition,
+  Future<T> waitFor<T>(FutureOr<T> Function() condition,
       {matcher,
       Duration timeout = defaultTimeout,
       Duration interval = defaultInterval}) async {


### PR DESCRIPTION
Currently, the `condition` function has an expected return type of `FutureOr<T>?`, which then forces the return types for all invocations to be nullable.

Instead, for methods that actually return a null, the generic instantiation itself can use a nullable value for `T`. That way, code that always return non-null values do not need to check for null values.