### PR TITLE
misc updates and rev in prep for publishing

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+# Dependabot configuration file.
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.1-dev
+## 3.0.1
 
 * Return Future with non-nullable generic from `waitFor`. The generic `T` may
   still be a nullable type where required.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![CI](https://github.com/google/webdriver.dart/actions/workflows/ci.yaml/badge.svg)](https://github.com/google/webdriver.dart/actions/workflows/ci.yaml)
 [![pub package](https://img.shields.io/pub/v/webdriver.svg)](https://pub.dartlang.org/packages/webdriver)
 
 Provides WebDriver bindings for Dart. These use the WebDriver JSON interface,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,8 @@
 name: webdriver
-version: 3.0.1-dev
-
+version: 3.0.1
 description: >-
-  Provides WebDriver bindings for Dart.
-  Supports WebDriver JSON interface and W3C spec.
-  Requires the use of WebDriver remote server.
-
+  Provides WebDriver bindings for Dart. Supports WebDriver JSON interface and
+  W3C spec. Requires the use of WebDriver remote server.
 repository: https://github.com/google/webdriver.dart
 
 environment:


### PR DESCRIPTION
- rev the package version in preparation for publishing
- add a dependabot configuration
- update the markdown badges

This also captures a previous change to switch the `homepage` pubspec field to `repository`.