### PR TITLE
remove the dep on package:archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Require Dart 2.18
 * "Officially" deprecate `core.dart` and `io.dart` libraries.
+* Remove the dependecy on `package:archive`.
 
 ## 3.0.1
 

--- a/lib/src/common/zip.dart
+++ b/lib/src/common/zip.dart
@@ -1,0 +1,265 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+// Zip format docs:
+// - https://en.wikipedia.org/wiki/ZIP_(file_format)
+// - https://users.cs.jmu.edu/buchhofp/forensics/formats/pkzip.html
+
+/// The class represents a general archive - a collection of files.
+class Archive {
+  final List<ArchiveFile> _files = [];
+
+  List<ArchiveFile> get files => List.unmodifiable(_files);
+
+  void addFile(ArchiveFile file) {
+    _files.add(file);
+  }
+}
+
+/// This class represents a file in an archive.
+class ArchiveFile {
+  final String name;
+  final List<int> content;
+
+  ArchiveFile(this.name, this.content);
+
+  int get length => content.length;
+}
+
+/// This zip encoder class encodes an [Archive] into a byte stream.
+///
+/// It does not attempt to compress the file entries, encode file modification
+/// times, or encode OS file permissions.
+class ZipEncoder {
+  ZipEncoder._();
+
+  static Uint8List encode(Archive archive) {
+    final buffer = BytesBuilder();
+
+    final fileOffsets = <ArchiveFile, int>{};
+
+    // write the files
+    for (var file in archive.files) {
+      final filenameData = utf8.encode(file.name);
+
+      fileOffsets[file] = buffer.length;
+
+      buffer.addUInt32(0x04034b50); // PK\3\4
+      buffer.addUInt16(10); // version needed to extract
+      buffer.addUInt16(0); // General purpose bit flag
+      buffer.addUInt16(0); // Compression method (0 == none)
+      buffer.addUInt16(0); // File last modification time
+      buffer.addUInt16(0); // File last modification date
+      buffer.addUInt32(crc32(file.content)); // CRC-32 of uncompressed data
+      buffer.addUInt32(file.length); // Compressed size
+      buffer.addUInt32(file.length); // Uncompressed size
+      buffer.addUInt16(filenameData.length); // File name length
+      buffer.addUInt16(0); // Extra field length
+      buffer.add(filenameData); // File name
+      /* none */ // Extra field
+
+      buffer.add(file.content);
+    }
+
+    final centralDirectoryOffset = buffer.length;
+
+    // write the central directory file headers
+    for (var file in archive.files) {
+      final filenameData = utf8.encode(file.name);
+
+      buffer.addUInt32(0x02014b50); // PK\1\2
+      buffer.addUInt16(0); // Version made by
+      buffer.addUInt16(10); // Version needed to extract (minimum)
+      buffer.addUInt16(0); // General purpose bit flag
+      buffer.addUInt16(0); // Compression method
+      buffer.addUInt16(0); // File last modification time
+      buffer.addUInt16(0); // File last modification date
+      buffer.addUInt32(crc32(file.content)); // CRC-32 of uncompressed data
+      buffer.addUInt32(file.length); // Compressed size
+      buffer.addUInt32(file.length); // Uncompressed size
+      buffer.addUInt16(filenameData.length); // File name length (n)
+      buffer.addUInt16(0); // Extra field length (m)
+      buffer.addUInt16(0); // File comment length (k)
+      buffer.addUInt16(0); // Disk number where file starts
+      buffer.addUInt16(0); // Internal file attributes
+      buffer.addUInt32(0); // External file attributes
+      buffer.addUInt32(fileOffsets[file]!); // Relative offset of file header
+      buffer.add(filenameData); // n File name
+      /* none */ // m Extra field
+      /* none */ // k File comment
+    }
+
+    final centralDirectorySize = buffer.length - centralDirectoryOffset;
+
+    final fileCount = archive.files.length;
+
+    // write the end of central directory record
+    buffer.addUInt32(0x06054b50); // PK\5\6
+    buffer.addUInt16(0); // Number of this disk
+    buffer.addUInt16(0); // Disk where central directory starts
+    buffer.addUInt16(fileCount); // central directory record count on disk
+    buffer.addUInt16(fileCount); // Total number of central directory records
+    buffer.addUInt32(centralDirectorySize); // Size of central directory
+    buffer.addUInt32(centralDirectoryOffset); // Offset of central directory
+    buffer.addUInt16(0); // Comment length (n)
+    /* none */ // n Comment
+
+    return buffer.toBytes();
+  }
+}
+
+/// Decodes a byte stream into an [Archive]. This is only intended for round-
+/// tripping the [ZipEncoder] class for testing purposes - it is not intended
+/// for general-purpose zip decoding.
+///
+/// visible-for-testing
+class ZipDecoder {
+  ZipDecoder._();
+
+  static Archive decodeBytes(List<int> zipData) {
+    final data = Uint8List.fromList(zipData).buffer.asByteData();
+    final archive = Archive();
+
+    // read the end of central directory record
+    int? directoryStart;
+
+    for (var i = data.lengthInBytes - 22; i > 0; i--) {
+      if (data.getUint32(i, Endian.little) == 0x06054b50) {
+        directoryStart = i;
+        break;
+      }
+    }
+
+    if (directoryStart == null) {
+      throw 'end of central directory record not found';
+    }
+
+    final fileCount = data.getUint16(directoryStart + 10, Endian.little);
+    final directoryOffset = data.getUint32(directoryStart + 16, Endian.little);
+
+    var offset = directoryOffset;
+
+    // read the central directory file headers
+    for (var i = 0; i < fileCount; i++) {
+      final compressionMethod = data.getUint16(offset + 10, Endian.little);
+      final compressedSize = data.getUint32(offset + 20, Endian.little);
+      final filenameLength = data.getUint16(offset + 28, Endian.little);
+      final extraFieldLength = data.getUint16(offset + 30, Endian.little);
+      final fileCommentLength = data.getUint16(offset + 32, Endian.little);
+      final fileHeaderOffset = data.getUint16(offset + 42, Endian.little);
+
+      if (compressionMethod != 0) {
+        throw 'unhandled compression method: $compressionMethod';
+      }
+
+      final filename =
+          utf8.decode(data.buffer.asUint8List(offset + 46, filenameLength));
+      final contents = _readFileData(data, fileHeaderOffset, compressedSize);
+
+      offset += 46 + filenameLength + extraFieldLength + fileCommentLength;
+
+      archive.addFile(ArchiveFile(filename, contents));
+    }
+
+    return archive;
+  }
+
+  static Uint8List _readFileData(
+      ByteData data, int offset, int compressedSize) {
+    final filenameLength = data.getUint16(offset + 26, Endian.little);
+    final extraFieldLength = data.getUint16(offset + 28, Endian.little);
+
+    return data.buffer.asUint8List(
+      offset + 30 + filenameLength + extraFieldLength,
+      compressedSize,
+    );
+  }
+}
+
+extension IntWriter on BytesBuilder {
+  void addUInt16(int value) {
+    addByte(value & 0xFF);
+    addByte((value >> 8) & 0xFF);
+  }
+
+  void addUInt32(int value) {
+    addByte(value & 0xFF);
+    addByte((value >> 8) & 0xFF);
+    addByte((value >> 16) & 0xFF);
+    addByte((value >> 24) & 0xFF);
+  }
+}
+
+/// Calculate the CRC-32 checksum of the given array.
+int crc32(List<int> array) {
+  final len = array.length;
+
+  var crc = 0;
+  crc = crc ^ 0xFFFFFFFF;
+
+  for (var ip = 0; ip < len; ip++) {
+    crc = _crc32Table[(crc ^ array[ip]) & 0xFF] ^ (crc >> 8);
+  }
+
+  return crc ^ 0xFFFFFFFF;
+}
+
+const List<int> _crc32Table = [
+  0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA, 0x076DC419, 0x706AF48F, //
+  0xE963A535, 0x9E6495A3, 0x0EDB8832, 0x79DCB8A4, 0xE0D5E91E, 0x97D2D988, //
+  0x09B64C2B, 0x7EB17CBD, 0xE7B82D07, 0x90BF1D91, 0x1DB71064, 0x6AB020F2, //
+  0xF3B97148, 0x84BE41DE, 0x1ADAD47D, 0x6DDDE4EB, 0xF4D4B551, 0x83D385C7, //
+  0x136C9856, 0x646BA8C0, 0xFD62F97A, 0x8A65C9EC, 0x14015C4F, 0x63066CD9, //
+  0xFA0F3D63, 0x8D080DF5, 0x3B6E20C8, 0x4C69105E, 0xD56041E4, 0xA2677172, //
+  0x3C03E4D1, 0x4B04D447, 0xD20D85FD, 0xA50AB56B, 0x35B5A8FA, 0x42B2986C, //
+  0xDBBBC9D6, 0xACBCF940, 0x32D86CE3, 0x45DF5C75, 0xDCD60DCF, 0xABD13D59, //
+  0x26D930AC, 0x51DE003A, 0xC8D75180, 0xBFD06116, 0x21B4F4B5, 0x56B3C423, //
+  0xCFBA9599, 0xB8BDA50F, 0x2802B89E, 0x5F058808, 0xC60CD9B2, 0xB10BE924, //
+  0x2F6F7C87, 0x58684C11, 0xC1611DAB, 0xB6662D3D, 0x76DC4190, 0x01DB7106, //
+  0x98D220BC, 0xEFD5102A, 0x71B18589, 0x06B6B51F, 0x9FBFE4A5, 0xE8B8D433, //
+  0x7807C9A2, 0x0F00F934, 0x9609A88E, 0xE10E9818, 0x7F6A0DBB, 0x086D3D2D, //
+  0x91646C97, 0xE6635C01, 0x6B6B51F4, 0x1C6C6162, 0x856530D8, 0xF262004E, //
+  0x6C0695ED, 0x1B01A57B, 0x8208F4C1, 0xF50FC457, 0x65B0D9C6, 0x12B7E950, //
+  0x8BBEB8EA, 0xFCB9887C, 0x62DD1DDF, 0x15DA2D49, 0x8CD37CF3, 0xFBD44C65, //
+  0x4DB26158, 0x3AB551CE, 0xA3BC0074, 0xD4BB30E2, 0x4ADFA541, 0x3DD895D7, //
+  0xA4D1C46D, 0xD3D6F4FB, 0x4369E96A, 0x346ED9FC, 0xAD678846, 0xDA60B8D0, //
+  0x44042D73, 0x33031DE5, 0xAA0A4C5F, 0xDD0D7CC9, 0x5005713C, 0x270241AA, //
+  0xBE0B1010, 0xC90C2086, 0x5768B525, 0x206F85B3, 0xB966D409, 0xCE61E49F, //
+  0x5EDEF90E, 0x29D9C998, 0xB0D09822, 0xC7D7A8B4, 0x59B33D17, 0x2EB40D81, //
+  0xB7BD5C3B, 0xC0BA6CAD, 0xEDB88320, 0x9ABFB3B6, 0x03B6E20C, 0x74B1D29A, //
+  0xEAD54739, 0x9DD277AF, 0x04DB2615, 0x73DC1683, 0xE3630B12, 0x94643B84, //
+  0x0D6D6A3E, 0x7A6A5AA8, 0xE40ECF0B, 0x9309FF9D, 0x0A00AE27, 0x7D079EB1, //
+  0xF00F9344, 0x8708A3D2, 0x1E01F268, 0x6906C2FE, 0xF762575D, 0x806567CB, //
+  0x196C3671, 0x6E6B06E7, 0xFED41B76, 0x89D32BE0, 0x10DA7A5A, 0x67DD4ACC, //
+  0xF9B9DF6F, 0x8EBEEFF9, 0x17B7BE43, 0x60B08ED5, 0xD6D6A3E8, 0xA1D1937E, //
+  0x38D8C2C4, 0x4FDFF252, 0xD1BB67F1, 0xA6BC5767, 0x3FB506DD, 0x48B2364B, //
+  0xD80D2BDA, 0xAF0A1B4C, 0x36034AF6, 0x41047A60, 0xDF60EFC3, 0xA867DF55, //
+  0x316E8EEF, 0x4669BE79, 0xCB61B38C, 0xBC66831A, 0x256FD2A0, 0x5268E236, //
+  0xCC0C7795, 0xBB0B4703, 0x220216B9, 0x5505262F, 0xC5BA3BBE, 0xB2BD0B28, //
+  0x2BB45A92, 0x5CB36A04, 0xC2D7FFA7, 0xB5D0CF31, 0x2CD99E8B, 0x5BDEAE1D, //
+  0x9B64C2B0, 0xEC63F226, 0x756AA39C, 0x026D930A, 0x9C0906A9, 0xEB0E363F, //
+  0x72076785, 0x05005713, 0x95BF4A82, 0xE2B87A14, 0x7BB12BAE, 0x0CB61B38, //
+  0x92D28E9B, 0xE5D5BE0D, 0x7CDCEFB7, 0x0BDBDF21, 0x86D3D2D4, 0xF1D4E242, //
+  0x68DDB3F8, 0x1FDA836E, 0x81BE16CD, 0xF6B9265B, 0x6FB077E1, 0x18B74777, //
+  0x88085AE6, 0xFF0F6A70, 0x66063BCA, 0x11010B5C, 0x8F659EFF, 0xF862AE69, //
+  0x616BFFD3, 0x166CCF45, 0xA00AE278, 0xD70DD2EE, 0x4E048354, 0x3903B3C2, //
+  0xA7672661, 0xD06016F7, 0x4969474D, 0x3E6E77DB, 0xAED16A4A, 0xD9D65ADC, //
+  0x40DF0B66, 0x37D83BF0, 0xA9BCAE53, 0xDEBB9EC5, 0x47B2CF7F, 0x30B5FFE9, //
+  0xBDBDF21C, 0xCABAC28A, 0x53B39330, 0x24B4A3A6, 0xBAD03605, 0xCDD70693, //
+  0x54DE5729, 0x23D967BF, 0xB3667A2E, 0xC4614AB8, 0x5D681B02, 0x2A6F2B94, //
+  0xB40BBE37, 0xC30C8EA1, 0x5A05DF1B, 0x2D02EF8D, //
+];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
   sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
-  archive: ^3.0.0
   matcher: ^0.12.10
   path: ^1.8.0
   stack_trace: ^1.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,5 +15,6 @@ dependencies:
   sync_http: ^0.3.0
 
 dev_dependencies:
+  archive: ^3.3.0
   lints: ^2.0.0
   test: ^1.16.0

--- a/test/support/firefox_profile_test.dart
+++ b/test/support/firefox_profile_test.dart
@@ -19,9 +19,9 @@ library webdriver.support.firefox_profile_test;
 import 'dart:convert' show base64, Encoding, utf8;
 import 'dart:io' as io;
 
-import 'package:archive/archive.dart' show Archive, ArchiveFile, ZipDecoder;
 import 'package:test/test.dart';
 import 'package:webdriver/async_core.dart';
+import 'package:webdriver/src/common/zip.dart';
 import 'package:webdriver/support/firefox_profile.dart';
 
 void main() {
@@ -140,8 +140,7 @@ void main() {
 
       final prefs = FirefoxProfile.loadPrefsFile(MockFile(
         String.fromCharCodes(
-          archive.files.firstWhere((f) => f.name == 'user.js').content
-              as List<int>,
+          archive.files.firstWhere((f) => f.name == 'user.js').content,
         ),
       ));
       expect(
@@ -166,7 +165,6 @@ void main() {
         'prefs.js',
         'user.js',
         'addons.js',
-        'webapps/',
         'webapps/webapps.json'
       ];
       expect(archive.files.length, greaterThanOrEqualTo(expectedFiles.length));
@@ -178,8 +176,7 @@ void main() {
       final prefs = FirefoxProfile.loadPrefsFile(
         MockFile(
           String.fromCharCodes(
-            archive.files.firstWhere((f) => f.name == 'user.js').content
-                as List<int>,
+            archive.files.firstWhere((f) => f.name == 'user.js').content,
           ),
         ),
       );
@@ -196,8 +193,8 @@ void main() {
 }
 
 Archive unpackArchiveData(Map profileData) {
-  final zipArchive = base64.decode(profileData['firefox_profile'] as String);
-  return ZipDecoder().decodeBytes(zipArchive, verify: true);
+  final zipData = base64.decode(profileData['firefox_profile'] as String);
+  return ZipDecoder.decodeBytes(zipData);
 }
 
 /// Simulate file for `FirefoxProfile.loadPrefsFile()`

--- a/test/support/zip_test.dart
+++ b/test/support/zip_test.dart
@@ -14,6 +14,7 @@
 
 import 'dart:convert';
 
+import 'package:archive/archive_io.dart' as archive;
 import 'package:test/test.dart';
 import 'package:webdriver/src/common/zip.dart';
 
@@ -21,51 +22,51 @@ void main() {
   group('zip', () {
     test('decode', () {
       final zipData = base64.decode(testZipBase64);
-      final archive = ZipDecoder.decodeBytes(zipData);
+      final zipArchive = archive.ZipDecoder().decodeBytes(zipData);
 
-      expect(archive.files, hasLength(2));
+      expect(zipArchive.files, hasLength(2));
 
-      var file = archive.files[0];
+      var file = zipArchive.files[0];
       expect(file.name, 'dart_test.yaml');
-      expect(file.length, 166);
-      expect(utf8.decode(file.content),
+      expect(file.size, 166);
+      expect(utf8.decode(file.content as List<int>),
           contains('See https://github.com/dart-lang/test/'));
 
-      file = archive.files[1];
+      file = zipArchive.files[1];
       expect(file.name, 'lib/src/common/spec.dart');
-      expect(file.length, 209);
-      expect(utf8.decode(file.content),
+      expect(file.size, 209);
+      expect(utf8.decode(file.content as List<int>),
           contains('Defines the WebDriver spec to use'));
     });
 
     test('round-trip', () {
-      final archive = Archive();
+      final zipArchive = Archive();
       const aaaContents = 'aaa';
       const bbbContents = 'bbb';
       final cccContents = 'c' * 1024;
 
-      archive.addFile(ArchiveFile('aaa.txt', utf8.encode(aaaContents)));
-      archive.addFile(ArchiveFile('bbb.txt', utf8.encode(bbbContents)));
-      archive.addFile(ArchiveFile('ccc/ccc.txt', utf8.encode(cccContents)));
+      zipArchive.addFile(ArchiveFile('aaa.txt', utf8.encode(aaaContents)));
+      zipArchive.addFile(ArchiveFile('bbb.txt', utf8.encode(bbbContents)));
+      zipArchive.addFile(ArchiveFile('ccc/ccc.txt', utf8.encode(cccContents)));
 
-      final zipBytes = ZipEncoder.encode(archive);
+      final zipBytes = ZipEncoder.encode(zipArchive);
 
       expect(zipBytes, isNotEmpty);
 
-      final decodedArchive = ZipDecoder.decodeBytes(zipBytes);
+      final decodedArchive = archive.ZipDecoder().decodeBytes(zipBytes);
       expect(decodedArchive.files, hasLength(3));
 
-      var file = archive.files[0];
+      var file = zipArchive.files[0];
       expect(file.name, 'aaa.txt');
       expect(file.length, 3);
       expect(utf8.decode(file.content), equals('aaa'));
 
-      file = archive.files[1];
+      file = zipArchive.files[1];
       expect(file.name, 'bbb.txt');
       expect(file.length, 3);
       expect(utf8.decode(file.content), equals('bbb'));
 
-      file = archive.files[2];
+      file = zipArchive.files[2];
       expect(file.name, 'ccc/ccc.txt');
       expect(file.length, 1024);
       expect(utf8.decode(file.content), contains('cccccccccccccc'));

--- a/test/support/zip_test.dart
+++ b/test/support/zip_test.dart
@@ -1,0 +1,112 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:test/test.dart';
+import 'package:webdriver/src/common/zip.dart';
+
+void main() {
+  group('zip', () {
+    test('decode', () {
+      final zipData = base64.decode(testZipBase64);
+      final archive = ZipDecoder.decodeBytes(zipData);
+
+      expect(archive.files, hasLength(2));
+
+      var file = archive.files[0];
+      expect(file.name, 'dart_test.yaml');
+      expect(file.length, 166);
+      expect(utf8.decode(file.content),
+          contains('See https://github.com/dart-lang/test/'));
+
+      file = archive.files[1];
+      expect(file.name, 'lib/src/common/spec.dart');
+      expect(file.length, 209);
+      expect(utf8.decode(file.content),
+          contains('Defines the WebDriver spec to use'));
+    });
+
+    test('round-trip', () {
+      final archive = Archive();
+      const aaaContents = 'aaa';
+      const bbbContents = 'bbb';
+      final cccContents = 'c' * 1024;
+
+      archive.addFile(ArchiveFile('aaa.txt', utf8.encode(aaaContents)));
+      archive.addFile(ArchiveFile('bbb.txt', utf8.encode(bbbContents)));
+      archive.addFile(ArchiveFile('ccc/ccc.txt', utf8.encode(cccContents)));
+
+      final zipBytes = ZipEncoder.encode(archive);
+
+      expect(zipBytes, isNotEmpty);
+
+      final decodedArchive = ZipDecoder.decodeBytes(zipBytes);
+      expect(decodedArchive.files, hasLength(3));
+
+      var file = archive.files[0];
+      expect(file.name, 'aaa.txt');
+      expect(file.length, 3);
+      expect(utf8.decode(file.content), equals('aaa'));
+
+      file = archive.files[1];
+      expect(file.name, 'bbb.txt');
+      expect(file.length, 3);
+      expect(utf8.decode(file.content), equals('bbb'));
+
+      file = archive.files[2];
+      expect(file.name, 'ccc/ccc.txt');
+      expect(file.length, 1024);
+      expect(utf8.decode(file.content), contains('cccccccccccccc'));
+    });
+  });
+
+  group('crc32', () {
+    test('0 bytes', () {
+      expect(crc32([]), 0x00000000);
+    });
+
+    test('1 byte', () {
+      expect(crc32([0x00]), 0xD202EF8D);
+    });
+
+    test('1 byte redux', () {
+      expect(crc32([0x01]), 0xA505DF1B);
+    });
+
+    test('2 bytes', () {
+      expect(crc32([0x01, 0x02]), 0xB6CC4292);
+    });
+
+    test('test string', () {
+      expect(crc32(utf8.encode('My very long test string.')), 0x88B8252E);
+    });
+  });
+}
+
+const testZipBase64 =
+    'UEsDBAoAAAAAALw2alV+3V8lpgAAAKYAAAAOABwAZGFydF90ZXN0LnlhbWxVVAkAA4QQbWOEEG'
+    '1jdXgLAAEE9QEAAAQUAAAAIyBTZWUgaHR0cHM6Ly9naXRodWIuY29tL2RhcnQtbGFuZy90ZXN0'
+    'L2Jsb2IvbWFzdGVyL3BrZ3MvdGVzdC9kb2MvY29uZmlndXJhdGlvbi5tZAp0YWdzOgogIGZmOi'
+    'AjIHRlc3RzIHRoYXQgcnVuIG9uIEZpcmVmb3guIE90aGVycyB0ZXN0cyBhcmUgYXNzdW1lZCB0'
+    'byBydW4gb24gQ2hyb21lClBLAwQKAAAAAAC8NmpVezD5KdEAAADRAAAAGAAcAGxpYi9zcmMvY2'
+    '9tbW9uL3NwZWMuZGFydFVUCQADhBBtY4QQbWN1eAsAAQT1AQAABBQAAAAvLyBpZ25vcmVfZm9y'
+    'X2ZpbGU6IGNvbnN0YW50X2lkZW50aWZpZXJfbmFtZXMKCi8vLyBEZWZpbmVzIHRoZSBXZWJEcm'
+    'l2ZXIgc3BlYyB0byB1c2UuIEF1dG8gPSB0cnkgdG8gaW5mZXIgdGhlIHNwZWMgYmFzZWQgb24K'
+    'Ly8vIHRoZSByZXNwb25zZSBkdXJpbmcgc2Vzc2lvbiBjcmVhdGlvbi4KZW51bSBXZWJEcml2ZX'
+    'JTcGVjIHsgQXV0bywgSnNvbldpcmUsIFczYyB9ClBLAQIeAwoAAAAAALw2alV+3V8lpgAAAKYA'
+    'AAAOABgAAAAAAAAAAACkgQAAAABkYXJ0X3Rlc3QueWFtbFVUBQADhBBtY3V4CwABBPUBAAAEFA'
+    'AAAFBLAQIeAwoAAAAAALw2alV7MPkp0QAAANEAAAAYABgAAAAAAAAAAACkge4AAABsaWIvc3Jj'
+    'L2NvbW1vbi9zcGVjLmRhcnRVVAUAA4QQbWN1eAsAAQT1AQAABBQAAABQSwUGAAAAAAIAAgCyAA'
+    'AAEQIAAAAA';

--- a/test/sync/web_driver.dart
+++ b/test/sync/web_driver.dart
@@ -95,8 +95,8 @@ void runTests({WebDriverSpec spec = WebDriverSpec.Auto}) {
       });
 
       test('close/windows', () {
-        final numHandles = (driver.windows.toList()).length;
-        (driver.findElement(const By.partialLinkText('Open copy'))).click();
+        final numHandles = driver.windows.toList().length;
+        driver.findElement(const By.partialLinkText('Open copy')).click();
         sleep(const Duration(milliseconds: 500)); // Bit slow on Firefox.
         expect(driver.windows.toList(), hasLength(numHandles + 1));
         driver.window.close();
@@ -107,7 +107,7 @@ void runTests({WebDriverSpec spec = WebDriverSpec.Auto}) {
         final orig = driver.window;
         Window? next;
 
-        (driver.findElement(const By.partialLinkText('Open copy'))).click();
+        driver.findElement(const By.partialLinkText('Open copy')).click();
         sleep(const Duration(milliseconds: 500)); // Bit slow on Firefox.
         for (final window in driver.windows) {
           if (window != orig) {
@@ -123,7 +123,7 @@ void runTests({WebDriverSpec spec = WebDriverSpec.Auto}) {
       test('activeElement', () {
         var element = driver.activeElement!;
         expect(element.name, 'body');
-        (driver.findElement(const By.cssSelector('input[type=text]'))).click();
+        driver.findElement(const By.cssSelector('input[type=text]')).click();
         element = driver.activeElement!;
         expect(element.name, 'input');
       });


### PR DESCRIPTION
- remove the dep on package:archive
- fix https://github.com/google/webdriver.dart/issues/265

We made very light use of `package:archive` in this repo - it was used just to create in-memory zip files of firefox profile directories. Removing the dep allows consumers of this package to avoid the additional dependency as well the transitive deps of `archive`.

We replace `archive` with custom code that emits an in-memory zip file. The encoder has some limitations - including not trying to compress file entries - but the limitations aren't an issue for the use of zip files in this package.
