### PR TITLE
Add content-type to async xhr request headers.

### DIFF
--- a/lib/src/request/async_xhr_request_client.dart
+++ b/lib/src/request/async_xhr_request_client.dart
@@ -25,6 +25,9 @@ class AsyncXhrRequestClient extends AsyncRequestClient {
     };
 
     headers.addAll(_headers);
+    if (request.body != null && request.body!.isNotEmpty) {
+      headers['Content-Type'] ??= 'application/json';
+    }
 
     HttpRequest httpRequest;
 


### PR DESCRIPTION
This header is already provided in `async_io_request_client.dart`, this adds the same logic to the html implementation of the async request client.

Rationale: A content-type header is needed to support geckodriver 0.27.0+ . Since the geckodriver started rejecting POST requests that contain an invalid content-type header. For more context, see the [geckodriver 0.27.0 release notes][1], and [CVE][2] explaining why this restriction was added.

Let me know if there is a recommended way to add test coverage for this. For now, I've tested this in our internal systems via bazel and integration tests that rely on this logic and use firefox and geckodriver.

[1]: https://github.com/mozilla/geckodriver/releases/tag/v0.27.0
[2]: https://github.com/advisories/GHSA-jxv7-gvxq-248q