### PR TITLE
Support getting current timeouts in sync w3c drivers.

### DIFF
--- a/lib/src/common/timeouts.dart
+++ b/lib/src/common/timeouts.dart
@@ -1,0 +1,22 @@
+class TimeoutValues {
+  final Duration script;
+  final Duration implicit;
+  final Duration pageLoad;
+
+  TimeoutValues(
+      {required this.script, required this.implicit, required this.pageLoad});
+
+  @override
+  String toString() =>
+      'TimeoutValues(script: $script, implicit: $implicit, pageLoad: $pageLoad)';
+
+  @override
+  int get hashCode => Object.hashAll([script, implicit, pageLoad]);
+
+  @override
+  bool operator ==(Object other) =>
+      other is TimeoutValues &&
+      script == other.script &&
+      implicit == other.implicit &&
+      pageLoad == other.pageLoad;
+}

--- a/lib/src/common/webdriver_handler.dart
+++ b/lib/src/common/webdriver_handler.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import '../../async_core.dart';
 import 'request.dart';
 import 'session.dart';
+import 'timeouts.dart';
 
 /// Handler for spec related request building and response parsing.
 ///
@@ -502,6 +503,12 @@ abstract class TimeoutsHandler {
 
   /// Parses response for 'Set Page Load Timeout'.
   void parseSetPageLoadTimeoutResponse(WebDriverResponse response);
+
+  /// Builds request for 'Get Timeouts'.
+  WebDriverRequest buildGetTimeoutsRequest();
+
+  /// Parses response for 'Get Timeouts'.
+  TimeoutValues parseGetTimeoutsResponse(WebDriverResponse response);
 }
 
 /// Handler for retrieving logs.

--- a/lib/src/handler/json_wire/timeouts.dart
+++ b/lib/src/handler/json_wire/timeouts.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import '../../common/request.dart';
+import '../../common/timeouts.dart';
 import '../../common/webdriver_handler.dart';
 import 'utils.dart';
 
@@ -46,5 +47,17 @@ class JsonWireTimeoutsHandler extends TimeoutsHandler {
   @override
   void parseSetPageLoadTimeoutResponse(WebDriverResponse response) {
     parseJsonWireResponse(response);
+  }
+
+  @override
+  WebDriverRequest buildGetTimeoutsRequest() {
+    // Not supported by JSON protocol:
+    // https://www.selenium.dev/documentation/legacy/json_wire_protocol/#command-summary
+    throw UnimplementedError();
+  }
+
+  @override
+  TimeoutValues parseGetTimeoutsResponse(WebDriverResponse response) {
+    throw UnimplementedError();
   }
 }

--- a/lib/src/handler/w3c/timeouts.dart
+++ b/lib/src/handler/w3c/timeouts.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import '../../common/request.dart';
+import '../../common/timeouts.dart';
 import '../../common/webdriver_handler.dart';
 import 'utils.dart';
 
@@ -45,5 +46,19 @@ class W3cTimeoutsHandler extends TimeoutsHandler {
   @override
   void parseSetPageLoadTimeoutResponse(WebDriverResponse response) {
     parseW3cResponse(response);
+  }
+
+  @override
+  WebDriverRequest buildGetTimeoutsRequest() =>
+      WebDriverRequest.getRequest('timeouts');
+
+  @override
+  TimeoutValues parseGetTimeoutsResponse(WebDriverResponse response) {
+    final timeouts = parseW3cResponse(response) as Map<String, dynamic>;
+    return TimeoutValues(
+      script: Duration(milliseconds: timeouts['script'] as int),
+      implicit: Duration(milliseconds: timeouts['implicit'] as int),
+      pageLoad: Duration(milliseconds: timeouts['pageLoad'] as int),
+    );
   }
 }

--- a/lib/src/sync/timeouts.dart
+++ b/lib/src/sync/timeouts.dart
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 import '../common/request_client.dart';
+import '../common/timeouts.dart';
 import '../common/webdriver_handler.dart';
 
-/// Sets WebDriver timeouts.
+/// Sets or gets WebDriver timeouts.
 class Timeouts {
   final SyncRequestClient _client;
   final WebDriverHandler _handler;
@@ -39,6 +40,11 @@ class Timeouts {
     _client.send(_handler.timeouts.buildSetPageLoadTimeoutRequest(duration),
         _handler.timeouts.parseSetPageLoadTimeoutResponse);
   }
+
+  /// Gets the current timeout values.
+  TimeoutValues getAllTimeouts() => _client.send(
+      _handler.timeouts.buildGetTimeoutsRequest(),
+      _handler.timeouts.parseGetTimeoutsResponse);
 
   @override
   String toString() => '$_handler.timeouts($_client)';

--- a/test/firefox_timeouts_test.dart
+++ b/test/firefox_timeouts_test.dart
@@ -16,7 +16,7 @@
 import 'package:test/test.dart';
 import 'package:webdriver/sync_core.dart';
 
-import 'sync/timeouts.dart';
+import 'sync/timeouts_w3c.dart';
 
 void main() {
   runTests(spec: WebDriverSpec.W3c);

--- a/test/sync/timeouts_w3c.dart
+++ b/test/sync/timeouts_w3c.dart
@@ -1,0 +1,45 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library webdriver.options_test;
+
+import 'package:test/test.dart';
+import 'package:webdriver/src/common/timeouts.dart';
+import 'package:webdriver/sync_core.dart';
+
+import '../configs/sync_io_config.dart' as config;
+
+void runTests({WebDriverSpec spec = WebDriverSpec.Auto}) {
+  group('TimeOuts', () {
+    late WebDriver driver;
+
+    setUp(() {
+      driver = config.createTestDriver(spec: spec);
+    });
+
+    test('set all timeouts', () {
+      const five = Duration(seconds: 5);
+      const one = Duration(seconds: 1);
+      const ten = Duration(seconds: 10);
+
+      driver.timeouts.setScriptTimeout(five);
+      driver.timeouts.setImplicitTimeout(one);
+      driver.timeouts.setPageLoadTimeout(ten);
+
+      expect(driver.timeouts.getAllTimeouts(),
+          TimeoutValues(script: five, implicit: one, pageLoad: ten));
+    });
+  }, timeout: const Timeout(Duration(minutes: 2)));
+}


### PR DESCRIPTION
Uses the W3C "Get Timeouts" API:
https://www.w3.org/TR/webdriver1/#get-timeouts

There is no such API in the JSON API:
https://www.selenium.dev/documentation/legacy/json_wire_protocol/#command-summary

Rationale: Allows sync clients to temporarily change a timeout and then restore it back to what it was before (which doesn't work for async clients anyway).

Tested: Against geckodriver, and internally against Chrome.