### PR TITLE
Explicitly close http clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.1.0-wip
 
 * Add a `reason` argument to `Clock.waitFor`.
+* Explicitly close http clients on quit. 
 
 ## 3.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.0-wip
+## 3.1.0
 
 * Add a `reason` argument to `Clock.waitFor`.
 * Explicitly close http clients on quit. 

--- a/lib/async_core.dart
+++ b/lib/async_core.dart
@@ -62,6 +62,7 @@ Future<WebDriver> createDriver(
   final session = await client.send(
       handler.session.buildCreateRequest(desired: desired),
       handler.session.parseCreateResponse);
+  client.close();
 
   if (session.spec != WebDriverSpec.JsonWire &&
       session.spec != WebDriverSpec.W3c) {
@@ -90,6 +91,7 @@ Future<WebDriver> fromExistingSession(
 
   final session = await client.send(handler.session.buildInfoRequest(sessionId),
       (response) => handler.session.parseInfoResponse(response, sessionId));
+  client.close();
 
   if (session.spec != WebDriverSpec.JsonWire &&
       session.spec != WebDriverSpec.W3c) {

--- a/lib/src/async/web_driver.dart
+++ b/lib/src/async/web_driver.dart
@@ -126,10 +126,14 @@ class WebDriver implements SearchContext {
       _handler.core.parsePageSourceResponse);
 
   /// Quits the browser.
-  Future<void> quit({bool closeSession = true}) => closeSession
-      ? _client.send(_handler.core.buildDeleteSessionRequest(),
-          _handler.core.parseDeleteSessionResponse)
-      : Future.value();
+  Future<void> quit({bool closeSession = true}) async {
+    if (!closeSession) {
+      return;
+    }
+    await _client.send(_handler.core.buildDeleteSessionRequest(),
+        _handler.core.parseDeleteSessionResponse);
+    _client.close();
+  }
 
   /// Closes the current window.
   ///

--- a/lib/src/common/request_client.dart
+++ b/lib/src/common/request_client.dart
@@ -114,4 +114,6 @@ abstract class AsyncRequestClient extends RequestClient {
   }
 
   Future<WebDriverResponse> sendRaw(WebDriverRequest request);
+
+  void close() {}
 }

--- a/lib/src/request/async_io_request_client.dart
+++ b/lib/src/request/async_io_request_client.dart
@@ -60,4 +60,7 @@ class AsyncIoRequestClient extends AsyncRequestClient {
 
   @override
   String toString() => 'AsyncIo';
+
+  @override
+  void close() => client.close(force: true);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdriver
-version: 3.1.0-wip
+version: 3.1.0
 description: >-
   Provides WebDriver bindings for Dart. Supports WebDriver JSON interface and
   W3C spec. Requires the use of WebDriver remote server.


### PR DESCRIPTION
This allows to speed up shutdown for ~15 seconds in certain circumstances.