### PR TITLE
Add a client that uses package:http

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        sdk: [3.1, stable, dev]
+        sdk: [3.4, stable, dev]
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - uses: dart-lang/setup-dart@e630b99d28a3b71860378cafdc2a067c71107f94
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        sdk: [3.1, stable, dev]
+        sdk: [3.4, stable, dev]
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - uses: dart-lang/setup-dart@e630b99d28a3b71860378cafdc2a067c71107f94

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.2.0-wip
+
+* Require Dart 3.3 and add a dependency on `package:http`.
+* Add a new driver that uses `package:http` and accepts a custom `Client`
+  that can be used from the `async_http` library.
+
 ## 3.1.0
 
 * Add a `reason` argument to `Clock.waitFor`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.2.0-wip
 
-* Require Dart 3.3 and add a dependency on `package:http`.
+* Require Dart 3.4 and add a dependency on `package:http`.
 * Add a new driver that uses `package:http` and accepts a custom `Client`
   that can be used from the `async_http` library.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Migrate `dart:html` usages to `package:web`.
 * Add a new driver that uses `package:http` and accepts a custom `Client`
   that can be used from the `async_http` library.
+  Consider migrating `async_io` and `async_web` usages to `async_http`.
 * Ensure HTTP clients are closed if creating a session fails.
 
 ## 3.1.0

--- a/lib/async_http.dart
+++ b/lib/async_http.dart
@@ -16,11 +16,11 @@ import 'package:http/http.dart' as http show Client;
 
 import 'async_core.dart' as core
     show
+        WebDriver,
+        WebDriverSpec,
         createDriver,
         fromExistingSession,
-        fromExistingSessionSync,
-        WebDriver,
-        WebDriverSpec;
+        fromExistingSessionSync;
 import 'src/request/async_http_request_client.dart';
 
 export 'package:webdriver/async_core.dart'

--- a/lib/async_http.dart
+++ b/lib/async_http.dart
@@ -1,0 +1,95 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:http/http.dart' as http show Client;
+
+import 'async_core.dart' as core
+    show
+        createDriver,
+        fromExistingSession,
+        fromExistingSessionSync,
+        WebDriver,
+        WebDriverSpec;
+import 'src/request/async_http_request_client.dart';
+
+export 'package:webdriver/async_core.dart'
+    hide createDriver, fromExistingSession, fromExistingSessionSync;
+export 'package:webdriver/src/request/async_http_request_client.dart';
+
+/// Creates a new async WebDriver using [AsyncHttpRequestClient].
+///
+/// Note: WebDriver endpoints will be constructed using [resolve] against
+/// [uri]. Therefore, if [uri] does not end with a trailing slash, the
+/// last path component will be dropped.
+Future<core.WebDriver> createDriver({
+  Uri? uri,
+  Map<String, Object?>? desired,
+  core.WebDriverSpec spec = core.WebDriverSpec.Auto,
+  Map<String, String> webDriverHeaders = const {},
+  http.Client? httpClient,
+}) =>
+    core.createDriver(
+      (prefix) => AsyncHttpRequestClient(
+        prefix,
+        headers: webDriverHeaders,
+        httpClient: httpClient,
+      ),
+      uri: uri,
+      desired: desired,
+      spec: spec,
+    );
+
+/// Creates an async WebDriver from existing session using
+/// [AsyncHttpRequestClient].
+///
+/// Note: WebDriver endpoints will be constructed using [resolve] against
+/// [uri]. Therefore, if [uri] does not end with a trailing slash, the
+/// last path component will be dropped.
+Future<core.WebDriver> fromExistingSession(
+  String sessionId, {
+  Uri? uri,
+  core.WebDriverSpec spec = core.WebDriverSpec.Auto,
+  http.Client? httpClient,
+}) =>
+    core.fromExistingSession(
+      (prefix) => AsyncHttpRequestClient(prefix, httpClient: httpClient),
+      sessionId,
+      uri: uri,
+      spec: spec,
+    );
+
+/// Creates an async WebDriver from existing session with a sync function using
+/// [AsyncHttpRequestClient].
+///
+/// The function is sync, so all necessary information ([sessionId], [spec],
+/// [capabilities]) has to be given. Because otherwise, making a call to
+/// WebDriver server will make this function async.
+///
+/// Note: WebDriver endpoints will be constructed using [resolve] against
+/// [uri]. Therefore, if [uri] does not end with a trailing slash, the
+/// last path component will be dropped.
+core.WebDriver fromExistingSessionSync(
+  String sessionId,
+  core.WebDriverSpec spec, {
+  Uri? uri,
+  Map<String, Object?>? capabilities,
+  http.Client? httpClient,
+}) =>
+    core.fromExistingSessionSync(
+      (prefix) => AsyncHttpRequestClient(prefix, httpClient: httpClient),
+      sessionId,
+      spec,
+      uri: uri,
+      capabilities: capabilities,
+    );

--- a/lib/async_http.dart
+++ b/lib/async_http.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Google Inc. All Rights Reserved.
+// Copyright 2025 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/request/async_http_request_client.dart
+++ b/lib/src/request/async_http_request_client.dart
@@ -1,3 +1,17 @@
+// Copyright 2025 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'dart:async';
 import 'dart:convert' show utf8;
 

--- a/lib/src/request/async_http_request_client.dart
+++ b/lib/src/request/async_http_request_client.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+import 'dart:convert' show utf8;
+
+import 'package:http/http.dart' as http;
+
+import '../../support/async.dart';
+
+import '../common/request.dart';
+import '../common/request_client.dart';
+
+/// Async request client using the
+/// specified or default [http.Client] from `package:http`.
+class AsyncHttpRequestClient extends AsyncRequestClient {
+  final Lock _lock = Lock();
+  final Map<String, String> _headers;
+  final http.Client _httpClient;
+
+  AsyncHttpRequestClient(
+    super.prefix, {
+    Map<String, String> headers = const {},
+    http.Client? httpClient,
+  })  : _headers = headers,
+        _httpClient = httpClient ?? http.Client();
+
+  @override
+  Future<WebDriverResponse> sendRaw(WebDriverRequest request) async {
+    await _lock.acquire();
+
+    try {
+      final requestUri = resolve(request.uri!);
+      final httpRequest = http.Request(request.method!.name, requestUri)
+        ..followRedirects = true
+        ..headers.addAll(_headers)
+        ..headers.addAll({
+          'Accept': 'application/json',
+          'Accept-Charset': utf8.name,
+          'Cache-Control': 'no-cache',
+        });
+
+      final requestBody = request.body;
+      if (requestBody != null && requestBody.isNotEmpty) {
+        httpRequest
+          ..headers['Content-Type'] = 'application/json'
+          ..bodyBytes = utf8.encode(requestBody);
+      }
+
+      final response = await _httpClient.send(httpRequest);
+      return WebDriverResponse(
+        response.statusCode,
+        response.reasonPhrase,
+        await utf8.decodeStream(response.stream),
+      );
+    } finally {
+      _lock.release();
+    }
+  }
+
+  @override
+  String toString() => 'AsyncHttp';
+}

--- a/lib/src/request/async_xhr_request_client.dart
+++ b/lib/src/request/async_xhr_request_client.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+// TODO: Migrate to package:web.
+// ignore: deprecated_member_use
 import 'dart:html';
 
 import '../../support/async.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 repository: https://github.com/google/webdriver.dart
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dependencies:
   http: ^1.2.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,15 @@
 name: webdriver
-version: 3.1.0
+version: 3.2.0-wip
 description: >-
   Provides WebDriver bindings for Dart. Supports WebDriver JSON interface and
   W3C spec. Requires the use of WebDriver remote server.
 repository: https://github.com/google/webdriver.dart
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.3.0
 
 dependencies:
+  http: ^1.2.2
   matcher: ^0.12.10
   path: ^1.8.0
   stack_trace: ^1.10.0


### PR DESCRIPTION
Then in a future release, the other clients can be deprecated in favor of this one.