### PR TITLE
Migrate async_html from `dart:html` to `package:web`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        sdk: [3.1, stable, dev]
+        sdk: [3.4, stable, dev]
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - uses: dart-lang/setup-dart@e630b99d28a3b71860378cafdc2a067c71107f94
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        sdk: [3.1, stable, dev]
+        sdk: [3.4, stable, dev]
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - uses: dart-lang/setup-dart@e630b99d28a3b71860378cafdc2a067c71107f94

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.0-wip
+
+* Require Dart 3.4 and add a dependency on `package:web`.
+
 ## 3.1.0
 
 * Add a `reason` argument to `Clock.waitFor`.

--- a/lib/async_html.dart
+++ b/lib/async_html.dart
@@ -27,7 +27,7 @@ final Uri defaultUri = Uri.parse('http://127.0.0.1:4444/wd/hub/');
 
 /// Creates a new async WebDriver using [AsyncXhrRequestClient].
 ///
-/// This will bring in dependency on `dart:html`.
+/// This will bring in a dependency on the Dart web platform.
 /// Note: WebDriver endpoints will be constructed using [resolve] against
 /// [uri]. Therefore, if [uri] does not end with a trailing slash, the
 /// last path component will be dropped.
@@ -45,7 +45,7 @@ Future<core.WebDriver> createDriver(
 /// Creates an async WebDriver from existing session using
 /// [AsyncXhrRequestClient].
 ///
-/// This will bring in dependency on `dart:html`.
+/// This will bring in a dependency on the Dart web platform.
 /// Note: WebDriver endpoints will be constructed using [resolve] against
 /// [uri]. Therefore, if [uri] does not end with a trailing slash, the
 /// last path component will be dropped.
@@ -61,7 +61,7 @@ Future<core.WebDriver> fromExistingSession(String sessionId,
 /// [capabilities]) has to be given. Because otherwise, making a call to
 /// WebDriver server will make this function async.
 ///
-/// This will bring in dependency on `dart:html`.
+/// This will bring in a dependency on the Dart web platform.
 /// Note: WebDriver endpoints will be constructed using [resolve] against
 /// [uri]. Therefore, if [uri] does not end with a trailing slash, the
 /// last path component will be dropped.

--- a/lib/src/request/async_xhr_request_client.dart
+++ b/lib/src/request/async_xhr_request_client.dart
@@ -1,12 +1,13 @@
 import 'dart:async';
-import 'dart:html';
+
+import 'package:web/web.dart' as web;
 
 import '../../support/async.dart';
 
 import '../common/request.dart';
 import '../common/request_client.dart';
 
-/// Async request client using dart:html package.
+/// Async request client using `dart:js_interop` through `package:web`.
 ///
 /// On the low level, it's using XMLHttpRequest object (XHR).
 class AsyncXhrRequestClient extends AsyncRequestClient {
@@ -20,25 +21,23 @@ class AsyncXhrRequestClient extends AsyncRequestClient {
   Future<WebDriverResponse> sendRaw(WebDriverRequest request) async {
     await _lock.acquire();
 
-    final headers = {
-      'Accept': 'application/json',
-    };
-
-    headers.addAll(_headers);
-    if (request.body != null && request.body!.isNotEmpty) {
-      headers['Content-Type'] ??= 'application/json';
-    }
-
-    HttpRequest httpRequest;
-
+    web.XMLHttpRequest httpRequest;
     try {
-      httpRequest = await HttpRequest.request(resolve(request.uri!).toString(),
-          method: request.method!.name,
-          requestHeaders: headers,
-          sendData: request.body,
-          mimeType: 'application/json');
-    } on ProgressEvent catch (e) {
-      httpRequest = e.target as HttpRequest;
+      // ignore: deprecated_member_use
+      httpRequest = await web.HttpRequest.request(
+        resolve(request.uri!).toString(),
+        method: request.method!.name,
+        requestHeaders: {
+          ..._headers,
+          'Accept': 'application/json',
+          if (request.body?.isNotEmpty ?? false)
+            'Content-Type': 'application/json',
+        },
+        sendData: request.body,
+        mimeType: 'application/json',
+      );
+    } on web.ProgressEvent catch (e) {
+      httpRequest = e.target as web.XMLHttpRequest;
     } finally {
       _lock.release();
     }
@@ -46,7 +45,7 @@ class AsyncXhrRequestClient extends AsyncRequestClient {
     return WebDriverResponse(
       httpRequest.status,
       httpRequest.statusText,
-      httpRequest.response as String?,
+      httpRequest.responseText,
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,18 +1,19 @@
 name: webdriver
-version: 3.1.0
+version: 3.2.0-wip
 description: >-
   Provides WebDriver bindings for Dart. Supports WebDriver JSON interface and
   W3C spec. Requires the use of WebDriver remote server.
 repository: https://github.com/google/webdriver.dart
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.4.0
 
 dependencies:
   matcher: ^0.12.10
   path: ^1.8.0
   stack_trace: ^1.10.0
   sync_http: ^0.3.0
+  web: ^1.1.0
 
 dev_dependencies:
   archive: ^3.3.0


### PR DESCRIPTION
This migration uses the deprecated `HttpRequest` helper(s) from `package:web` so it doesn't need to reimplement any handling. Usages of this HTML client should likely migrate to https://github.com/google/webdriver.dart/pull/314.

Resolves https://github.com/google/webdriver.dart/issues/312