### PR TITLE
[Breaking] Replace usages of `dart:math` geometry types with custom types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.0-wip
+
+* Replace usages of `Point<int>` and `Rectangle<int>` from `dart:math` with
+  custom `Location`, `Rect`, and `Size` types.
+
 ## 3.1.0
 
 * Add a `reason` argument to `Clock.waitFor`.

--- a/lib/async_core.dart
+++ b/lib/async_core.dart
@@ -37,6 +37,7 @@ export 'package:webdriver/src/common/capabilities.dart';
 export 'package:webdriver/src/common/command_event.dart';
 export 'package:webdriver/src/common/cookie.dart';
 export 'package:webdriver/src/common/exception.dart';
+export 'package:webdriver/src/common/geometry.dart';
 export 'package:webdriver/src/common/log.dart';
 export 'package:webdriver/src/common/mouse.dart';
 export 'package:webdriver/src/common/spec.dart';

--- a/lib/src/async/web_element.dart
+++ b/lib/src/async/web_element.dart
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 import 'dart:async';
-import 'dart:math';
 
 import '../common/by.dart';
+import '../common/geometry.dart';
 import '../common/request_client.dart';
 import '../common/web_element.dart' as common;
 import '../common/webdriver_handler.dart';
@@ -75,20 +75,19 @@ class WebElement extends common.WebElement implements SearchContext {
       _handler.element.parseDisplayedResponse);
 
   /// The location within the document of this element.
-  Future<Point<int>> get location => _client.send(
+  Future<Position> get location => _client.send(
       _handler.element.buildLocationRequest(id),
       _handler.element.parseLocationResponse);
 
   /// The size of this element.
-  Future<Rectangle<int>> get size => _client.send(
-      _handler.element.buildSizeRequest(id),
+  Future<Size> get size => _client.send(_handler.element.buildSizeRequest(id),
       _handler.element.parseSizeResponse);
 
   /// The bounds of this element.
-  Future<Rectangle<int>> get rect async {
+  Future<Rect> get rect async {
     final location = await this.location;
     final size = await this.size;
-    return Rectangle<int>(location.x, location.y, size.width, size.height);
+    return Rect.from(topLeft: location, size: size);
   }
 
   /// The tag name for this element.

--- a/lib/src/async/window.dart
+++ b/lib/src/async/window.dart
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import 'dart:async';
-import 'dart:math';
 
+import '../common/geometry.dart';
 import '../common/request_client.dart';
 import '../common/webdriver_handler.dart';
 
@@ -31,21 +31,21 @@ class Window {
       _handler.window.parseSetActiveResponse);
 
   /// The location of the window.
-  Future<Point<int>> get location => _client.send(
+  Future<Position> get location => _client.send(
       _handler.window.buildLocationRequest(),
       _handler.window.parseLocationResponse);
 
   /// The outer size of the window.
-  Future<Rectangle<int>> get size => _client.send(
+  Future<Size> get size => _client.send(
       _handler.window.buildSizeRequest(), _handler.window.parseSizeResponse);
 
   /// The inner size of the window.
-  Future<Rectangle<int>> get innerSize => _client.send(
+  Future<Size> get innerSize => _client.send(
       _handler.window.buildInnerSizeRequest(),
       _handler.window.parseInnerSizeResponse);
 
   /// The location and size of the window.
-  Future<Rectangle<int>> get rect async {
+  Future<Rect> get rect async {
     try {
       return await _client.send(_handler.window.buildRectRequest(),
           _handler.window.parseRectResponse);
@@ -54,22 +54,22 @@ class Window {
       // Delegate to other methods.
       final location = await this.location;
       final size = await this.size;
-      return Rectangle<int>(location.x, location.y, size.width, size.height);
+      return Rect.from(topLeft: location, size: size);
     }
   }
 
   /// Sets the window location.
-  Future<void> setLocation(Point<int> point) => _client.send(
+  Future<void> setLocation(Position point) => _client.send(
       _handler.window.buildSetLocationRequest(point),
       _handler.window.parseSetLocationResponse);
 
   /// Sets the window size.
-  Future<void> setSize(Rectangle<int> size) => _client.send(
+  Future<void> setSize(Size size) => _client.send(
       _handler.window.buildSetSizeRequest(size),
       _handler.window.parseSetSizeResponse);
 
   /// The location and size of the window.
-  Future<void> setRect(Rectangle<int> rect) async {
+  Future<void> setRect(Rect rect) async {
     try {
       await _client.send(_handler.window.buildSetRectRequest(rect),
           _handler.window.parseSetRectResponse);
@@ -78,7 +78,7 @@ class Window {
       // JsonWire cannot implement this API in one call.
       // Delegate to other methods.
       await setLocation(rect.topLeft);
-      await setSize(Rectangle(0, 0, rect.width, rect.height));
+      await setSize(rect.size);
     }
   }
 

--- a/lib/src/common/geometry.dart
+++ b/lib/src/common/geometry.dart
@@ -1,0 +1,114 @@
+// Copyright 2025 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A two-dimensional location represented by [x] and [y] coordinates on
+/// a 2D-coordinate system where the origin `(0, 0)` is in the top-left corner.
+final class Position {
+  /// The x-coordinate of this position.
+  final int x;
+
+  /// The y-coordinate of this position.
+  final int y;
+
+  /// Create a location at the specified [x] and [y] coordinates.
+  const Position({required this.x, required this.y});
+}
+
+/// A rectangle, which is a quadrilateral with four right angles, represented on
+/// a 2D-coordinate system where the origin `(0, 0)` is in the top-left corner.
+final class Rect {
+  final int _left;
+  final int _top;
+  final int _width;
+  final int _height;
+
+  /// Create a rectangle with its upper-left corner at `(left, top)`
+  /// and its bottom right corner at `(left + width, top + height)`.
+  ///
+  /// [width] and [height] should both be non-negative.
+  /// If they aren't, they are clamped to zero.
+  const Rect({
+    required int left,
+    required int top,
+    required int width,
+    required int height,
+  })  : assert(width >= 0, height >= 0),
+        _top = top,
+        _left = left,
+        _width = (width < 0) ? 0 : width,
+        _height = (height < 0) ? 0 : height;
+
+  /// Create a rectangle with its upper-left corner at `(topLeft.x, topLeft.y)`
+  /// and its bottom right corner at `(topLeft.x + width, topLeft.y + height)`.
+  ///
+  /// The `width` and `height` of [Size] should both be non-negative.
+  factory Rect.from({required Position topLeft, required Size size}) => Rect(
+        left: topLeft.x,
+        top: topLeft.y,
+        width: size.width,
+        height: size.height,
+      );
+
+  /// The width of this rectangle.
+  int get width => _width;
+
+  /// The height of this rectangle.
+  int get height => _height;
+
+  /// The size of this rectangle.
+  Size get size => Size(width: _width, height: _height);
+
+  /// The x-coordinate of the left edge of this rectangle.
+  int get left => _left;
+
+  /// The y-coordinate of the top edge of this rectangle.
+  int get top => _top;
+
+  /// The x-coordinate of the right edge of this rectangle.
+  int get right => _left + _width;
+
+  /// The x-coordinate of the bottom edge of this rectangle.
+  int get bottom => _top + _height;
+
+  /// The location of the top-left corner of this rectangle.
+  Position get topLeft => Position(x: left, y: top);
+
+  /// The location of the top-right corner of this rectangle.
+  Position get topRight => Position(x: right, y: top);
+
+  /// The location of the bottom-right corner of this rectangle.
+  Position get bottomRight => Position(x: right, y: bottom);
+
+  /// The location of the bottom-left corner of this rectangle.
+  Position get bottomLeft => Position(x: left, y: bottom);
+}
+
+/// The width and height dimensions of a 2D object.
+final class Size {
+  /// The width dimension.
+  final int width;
+
+  /// The height dimension.
+  final int height;
+
+  /// Create a size that represents the
+  /// specified [width] and [height] dimensions.
+  ///
+  /// [width] and [height] should both be non-negative.
+  /// If they aren't, they are clamped to zero.
+  const Size({required int width, required int height})
+      : assert(width >= 0, height >= 0),
+        width = (width < 0) ? 0 : width,
+        height = (height < 0) ? 0 : height;
+}

--- a/lib/src/common/webdriver_handler.dart
+++ b/lib/src/common/webdriver_handler.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import '../../async_core.dart';
 import 'request.dart';
 import 'session.dart';
@@ -157,7 +155,7 @@ abstract class ElementHandler {
   WebDriverRequest buildLocationRequest(String elementId);
 
   /// Parses response for 'Element Location'.
-  Point<int> parseLocationResponse(WebDriverResponse response);
+  Position parseLocationResponse(WebDriverResponse response);
 
   /// Builds request for 'Element Size'.
   WebDriverRequest buildSizeRequest(String elementId);
@@ -165,7 +163,7 @@ abstract class ElementHandler {
   /// Parses response for 'Element Size'.
   ///
   /// This will be the rectangle moved to (0, 0).
-  Rectangle<int> parseSizeResponse(WebDriverResponse response);
+  Size parseSizeResponse(WebDriverResponse response);
 
   /// Builds request for 'Element Name'.
   WebDriverRequest buildNameRequest(String elementId);
@@ -363,7 +361,7 @@ abstract class WindowHandler {
   WebDriverRequest buildLocationRequest();
 
   /// Parses response for 'Window Location'.
-  Point<int> parseLocationResponse(WebDriverResponse response);
+  Position parseLocationResponse(WebDriverResponse response);
 
   /// Builds request for 'Window Size'.
   WebDriverRequest buildSizeRequest();
@@ -371,28 +369,28 @@ abstract class WindowHandler {
   /// Parses response for 'Window Size'.
   ///
   /// This will be the rectangle moved to (0, 0).
-  Rectangle<int> parseSizeResponse(WebDriverResponse response);
+  Size parseSizeResponse(WebDriverResponse response);
 
   /// Builds request for 'Window Rect'.
   WebDriverRequest buildRectRequest();
 
   /// Parses response for 'Window Rect'.
-  Rectangle<int> parseRectResponse(WebDriverResponse response);
+  Rect parseRectResponse(WebDriverResponse response);
 
   /// Builds request for 'Set Window Location'.
-  WebDriverRequest buildSetLocationRequest(Point<int> location);
+  WebDriverRequest buildSetLocationRequest(Position location);
 
   /// Parses response for 'Set Window Location'.
   void parseSetLocationResponse(WebDriverResponse response);
 
   /// Builds request for 'Set Window Size'.
-  WebDriverRequest buildSetSizeRequest(Rectangle<int> size);
+  WebDriverRequest buildSetSizeRequest(Size size);
 
   /// Parses response for 'Set Window Size'.
   void parseSetSizeResponse(WebDriverResponse response);
 
   /// Builds request for 'Set Window Rect'.
-  WebDriverRequest buildSetRectRequest(Rectangle<int> rect);
+  WebDriverRequest buildSetRectRequest(Rect rect);
 
   /// Parses response for 'Set Window Rect'.
   void parseSetRectResponse(WebDriverResponse response);
@@ -423,7 +421,7 @@ abstract class WindowHandler {
   WebDriverRequest buildInnerSizeRequest();
 
   /// Parses response for 'Inner Size'.
-  Rectangle<int> parseInnerSizeResponse(WebDriverResponse response);
+  Size parseInnerSizeResponse(WebDriverResponse response);
 }
 
 abstract class FrameHandler {

--- a/lib/src/handler/json_wire/element.dart
+++ b/lib/src/handler/json_wire/element.dart
@@ -1,5 +1,4 @@
-import 'dart:math';
-
+import '../../common/geometry.dart';
 import '../../common/request.dart';
 import '../../common/webdriver_handler.dart';
 import 'utils.dart';
@@ -63,9 +62,12 @@ class JsonWireElementHandler extends ElementHandler {
       WebDriverRequest.getRequest('${elementPrefix(elementId)}location');
 
   @override
-  Point<int> parseLocationResponse(WebDriverResponse response) {
-    final point = parseJsonWireResponse(response) as Map;
-    return Point((point['x'] as num).toInt(), (point['y'] as num).toInt());
+  Position parseLocationResponse(WebDriverResponse response) {
+    final point = parseJsonWireResponse(response) as Map<String, Object?>;
+    return Position(
+      x: (point['x'] as num).toInt(),
+      y: (point['y'] as num).toInt(),
+    );
   }
 
   @override
@@ -73,13 +75,11 @@ class JsonWireElementHandler extends ElementHandler {
       WebDriverRequest.getRequest('${elementPrefix(elementId)}size');
 
   @override
-  Rectangle<int> parseSizeResponse(WebDriverResponse response) {
-    final size = parseJsonWireResponse(response) as Map;
-    return Rectangle<int>(
-      0,
-      0,
-      (size['width'] as num).toInt(),
-      (size['height'] as num).toInt(),
+  Size parseSizeResponse(WebDriverResponse response) {
+    final size = parseJsonWireResponse(response) as Map<String, Object?>;
+    return Size(
+      width: (size['width'] as num).toInt(),
+      height: (size['height'] as num).toInt(),
     );
   }
 

--- a/lib/src/handler/json_wire/window.dart
+++ b/lib/src/handler/json_wire/window.dart
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:math';
-
+import '../../common/geometry.dart';
 import '../../common/request.dart';
 import '../../common/webdriver_handler.dart';
 import 'utils.dart';
@@ -49,11 +48,11 @@ class JsonWireWindowHandler extends WindowHandler {
       WebDriverRequest.getRequest('window/current/position');
 
   @override
-  Point<int> parseLocationResponse(WebDriverResponse response) {
-    final point = parseJsonWireResponse(response) as Map;
-    return Point(
-      (point['x'] as num).toInt(),
-      (point['y'] as num).toInt(),
+  Position parseLocationResponse(WebDriverResponse response) {
+    final point = parseJsonWireResponse(response) as Map<String, Object?>;
+    return Position(
+      x: (point['x'] as num).toInt(),
+      y: (point['y'] as num).toInt(),
     );
   }
 
@@ -62,13 +61,11 @@ class JsonWireWindowHandler extends WindowHandler {
       WebDriverRequest.getRequest('window/current/size');
 
   @override
-  Rectangle<int> parseSizeResponse(WebDriverResponse response) {
-    final size = parseJsonWireResponse(response) as Map;
-    return Rectangle<int>(
-      0,
-      0,
-      (size['width'] as num).toInt(),
-      (size['height'] as num).toInt(),
+  Size parseSizeResponse(WebDriverResponse response) {
+    final size = parseJsonWireResponse(response) as Map<String, Object?>;
+    return Size(
+      width: (size['width'] as num).toInt(),
+      height: (size['height'] as num).toInt(),
     );
   }
 
@@ -78,14 +75,14 @@ class JsonWireWindowHandler extends WindowHandler {
   }
 
   @override
-  Rectangle<int> parseRectResponse(WebDriverResponse response) {
+  Rect parseRectResponse(WebDriverResponse response) {
     throw UnsupportedError('Get Window Rect is not supported in JsonWire.');
   }
 
   @override
-  WebDriverRequest buildSetLocationRequest(Point<int> location) =>
-      WebDriverRequest.postRequest('window/current/position',
-          {'x': location.x.toInt(), 'y': location.y.toInt()});
+  WebDriverRequest buildSetLocationRequest(Position location) =>
+      WebDriverRequest.postRequest(
+          'window/current/position', {'x': location.x, 'y': location.y});
 
   @override
   void parseSetLocationResponse(WebDriverResponse response) {
@@ -93,9 +90,9 @@ class JsonWireWindowHandler extends WindowHandler {
   }
 
   @override
-  WebDriverRequest buildSetSizeRequest(Rectangle<int> size) =>
-      WebDriverRequest.postRequest('window/current/size',
-          {'width': size.width.toInt(), 'height': size.height.toInt()});
+  WebDriverRequest buildSetSizeRequest(Size size) =>
+      WebDriverRequest.postRequest(
+          'window/current/size', {'width': size.width, 'height': size.height});
 
   @override
   void parseSetSizeResponse(WebDriverResponse response) {
@@ -103,7 +100,7 @@ class JsonWireWindowHandler extends WindowHandler {
   }
 
   @override
-  WebDriverRequest buildSetRectRequest(Rectangle<int> rect) {
+  WebDriverRequest buildSetRectRequest(Rect rect) {
     throw UnsupportedError('Set Window Rect is not supported in JsonWire.');
   }
 
@@ -146,8 +143,11 @@ class JsonWireWindowHandler extends WindowHandler {
       });
 
   @override
-  Rectangle<int> parseInnerSizeResponse(WebDriverResponse response) {
-    final size = parseJsonWireResponse(response) as Map;
-    return Rectangle(0, 0, size['width'] as int, size['height'] as int);
+  Size parseInnerSizeResponse(WebDriverResponse response) {
+    final size = parseJsonWireResponse(response) as Map<String, Object?>;
+    return Size(
+      width: (size['width'] as num).toInt(),
+      height: (size['height'] as num).toInt(),
+    );
   }
 }

--- a/lib/src/handler/w3c/element.dart
+++ b/lib/src/handler/w3c/element.dart
@@ -1,5 +1,4 @@
-import 'dart:math';
-
+import '../../common/geometry.dart';
 import '../../common/request.dart';
 import '../../common/webdriver_handler.dart';
 import 'utils.dart';
@@ -64,7 +63,7 @@ class W3cElementHandler extends ElementHandler {
       _buildRectRequest(elementId);
 
   @override
-  Point<int> parseLocationResponse(WebDriverResponse response) =>
+  Position parseLocationResponse(WebDriverResponse response) =>
       _parseRectResponse(response).topLeft;
 
   @override
@@ -72,21 +71,21 @@ class W3cElementHandler extends ElementHandler {
       _buildRectRequest(elementId);
 
   @override
-  Rectangle<int> parseSizeResponse(WebDriverResponse response) {
+  Size parseSizeResponse(WebDriverResponse response) {
     final rect = _parseRectResponse(response);
-    return Rectangle(0, 0, rect.width, rect.height);
+    return rect.size;
   }
 
   WebDriverRequest _buildRectRequest(String elementId) =>
       WebDriverRequest.getRequest('${elementPrefix(elementId)}rect');
 
-  Rectangle<int> _parseRectResponse(WebDriverResponse response) {
+  Rect _parseRectResponse(WebDriverResponse response) {
     final rect = parseW3cResponse(response);
-    return Rectangle(
-      (rect['x'] as num).toInt(),
-      (rect['y'] as num).toInt(),
-      (rect['width'] as num).toInt(),
-      (rect['height'] as num).toInt(),
+    return Rect(
+      left: (rect['x'] as num).toInt(),
+      top: (rect['y'] as num).toInt(),
+      width: (rect['width'] as num).toInt(),
+      height: (rect['height'] as num).toInt(),
     );
   }
 

--- a/lib/src/handler/w3c/window.dart
+++ b/lib/src/handler/w3c/window.dart
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:math';
-
+import '../../common/geometry.dart';
 import '../../common/request.dart';
 import '../../common/webdriver_handler.dart';
 import 'utils.dart';
@@ -48,16 +47,16 @@ class W3cWindowHandler extends WindowHandler {
   WebDriverRequest buildLocationRequest() => buildRectRequest();
 
   @override
-  Point<int> parseLocationResponse(WebDriverResponse response) =>
+  Position parseLocationResponse(WebDriverResponse response) =>
       parseRectResponse(response).topLeft;
 
   @override
   WebDriverRequest buildSizeRequest() => buildRectRequest();
 
   @override
-  Rectangle<int> parseSizeResponse(WebDriverResponse response) {
+  Size parseSizeResponse(WebDriverResponse response) {
     final rect = parseRectResponse(response);
-    return Rectangle(0, 0, rect.width, rect.height);
+    return rect.size;
   }
 
   @override
@@ -65,18 +64,18 @@ class W3cWindowHandler extends WindowHandler {
       WebDriverRequest.getRequest('window/rect');
 
   @override
-  Rectangle<int> parseRectResponse(WebDriverResponse response) {
+  Rect parseRectResponse(WebDriverResponse response) {
     final rect = parseW3cResponse(response);
-    return Rectangle(
-      (rect['x'] as num).toInt(),
-      (rect['y'] as num).toInt(),
-      (rect['width'] as num).toInt(),
-      (rect['height'] as num).toInt(),
+    return Rect(
+      left: (rect['x'] as num).toInt(),
+      top: (rect['y'] as num).toInt(),
+      width: (rect['width'] as num).toInt(),
+      height: (rect['height'] as num).toInt(),
     );
   }
 
   @override
-  WebDriverRequest buildSetLocationRequest(Point<int> location) =>
+  WebDriverRequest buildSetLocationRequest(Position location) =>
       WebDriverRequest.postRequest('window/rect', {
         'x': location.x,
         'y': location.y,
@@ -88,7 +87,7 @@ class W3cWindowHandler extends WindowHandler {
   }
 
   @override
-  WebDriverRequest buildSetSizeRequest(Rectangle<int> size) =>
+  WebDriverRequest buildSetSizeRequest(Size size) =>
       WebDriverRequest.postRequest(
           'window/rect', {'width': size.width, 'height': size.height});
 
@@ -98,7 +97,7 @@ class W3cWindowHandler extends WindowHandler {
   }
 
   @override
-  WebDriverRequest buildSetRectRequest(Rectangle<int> rect) =>
+  WebDriverRequest buildSetRectRequest(Rect rect) =>
       WebDriverRequest.postRequest('window/rect', {
         'x': rect.left,
         'y': rect.top,
@@ -147,8 +146,11 @@ class W3cWindowHandler extends WindowHandler {
       });
 
   @override
-  Rectangle<int> parseInnerSizeResponse(WebDriverResponse response) {
+  Size parseInnerSizeResponse(WebDriverResponse response) {
     final size = parseW3cResponse(response);
-    return Rectangle(0, 0, size['width'] as int, size['height'] as int);
+    return Size(
+      width: (size['width'] as num).toInt(),
+      height: (size['height'] as num).toInt(),
+    );
   }
 }

--- a/lib/src/sync/web_element.dart
+++ b/lib/src/sync/web_element.dart
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:math' show Point, Rectangle;
-
 import '../../async_core.dart' as async_core;
 import '../common/by.dart';
+import '../common/geometry.dart';
 import '../common/request_client.dart';
 import '../common/web_element.dart' as common;
 import '../common/webdriver_handler.dart';
@@ -144,19 +143,19 @@ class WebElement extends common.WebElement implements SearchContext {
   ///
   /// This is assumed to be the upper left corner of the element, but its
   /// implementation is not well defined in the JSON spec.
-  Point<int> get location => _client.send(
+  Position get location => _client.send(
       _handler.element.buildLocationRequest(id),
       _handler.element.parseLocationResponse);
 
   /// The size of this element.
-  Rectangle<int> get size => _client.send(_handler.element.buildSizeRequest(id),
+  Size get size => _client.send(_handler.element.buildSizeRequest(id),
       _handler.element.parseSizeResponse);
 
   /// The bounds of this element.
-  Rectangle<int> get rect {
+  Rect get rect {
     final location = this.location;
     final size = this.size;
-    return Rectangle<int>(location.x, location.y, size.width, size.height);
+    return Rect.from(topLeft: location, size: size);
   }
 
   /// The tag name for this element.

--- a/lib/src/sync/window.dart
+++ b/lib/src/sync/window.dart
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:math' show Point, Rectangle;
-
+import '../common/geometry.dart';
 import '../common/request_client.dart';
 import '../common/webdriver_handler.dart';
 
@@ -34,21 +33,19 @@ class Window {
   }
 
   /// The location of the window.
-  Point<int> get location => _client.send(
-      _handler.window.buildLocationRequest(),
+  Position get location => _client.send(_handler.window.buildLocationRequest(),
       _handler.window.parseLocationResponse);
 
   /// The outer size of the window.
-  Rectangle<int> get size => _client.send(
+  Size get size => _client.send(
       _handler.window.buildSizeRequest(), _handler.window.parseSizeResponse);
 
   /// The inner size of the window.
-  Rectangle<int> get innerSize => _client.send(
-      _handler.window.buildInnerSizeRequest(),
+  Size get innerSize => _client.send(_handler.window.buildInnerSizeRequest(),
       _handler.window.parseInnerSizeResponse);
 
   /// The location and size of the window.
-  Rectangle<int> get rect {
+  Rect get rect {
     try {
       return _client.send(_handler.window.buildRectRequest(),
           _handler.window.parseRectResponse);
@@ -57,19 +54,19 @@ class Window {
       // Delegate to other methods.
       final location = this.location;
       final size = this.size;
-      return Rectangle<int>(location.x, location.y, size.width, size.height);
+      return Rect.from(topLeft: location, size: size);
     }
   }
 
   /// Sets the window location.
   ///
   /// TODO(jingbian): Remove this, prefer setter.
-  void setLocation(Point<int> point) {
+  void setLocation(Position point) {
     location = point;
   }
 
   /// Sets the window location.
-  set location(Point<int> value) {
+  set location(Position value) {
     _client.send(_handler.window.buildSetLocationRequest(value),
         _handler.window.parseSetLocationResponse);
   }
@@ -77,18 +74,18 @@ class Window {
   /// Sets the window size.
   ///
   /// TODO(jingbian): Remove this, prefer setter.
-  void setSize(Rectangle<int> size) {
+  void setSize(Size size) {
     this.size = size;
   }
 
   /// Sets the window size.
-  set size(Rectangle<int> value) {
+  set size(Size value) {
     _client.send(_handler.window.buildSetSizeRequest(value),
         _handler.window.parseSetSizeResponse);
   }
 
   /// The location and size of the window.
-  set rect(Rectangle<int> value) {
+  set rect(Rect value) {
     try {
       _client.send(_handler.window.buildSetRectRequest(value),
           _handler.window.parseSetRectResponse);
@@ -97,7 +94,7 @@ class Window {
       // JsonWire cannot implement this API in one call.
       // Delegate to other methods.
       location = value.topLeft;
-      size = Rectangle(0, 0, value.width, value.height);
+      size = value.size;
     }
   }
 

--- a/lib/sync_core.dart
+++ b/lib/sync_core.dart
@@ -25,6 +25,7 @@ export 'package:webdriver/src/common/capabilities.dart';
 export 'package:webdriver/src/common/command_event.dart';
 export 'package:webdriver/src/common/cookie.dart';
 export 'package:webdriver/src/common/exception.dart';
+export 'package:webdriver/src/common/geometry.dart';
 export 'package:webdriver/src/common/log.dart';
 export 'package:webdriver/src/common/mouse.dart';
 export 'package:webdriver/src/common/spec.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdriver
-version: 3.1.0
+version: 4.0.0-wip
 description: >-
   Provides WebDriver bindings for Dart. Supports WebDriver JSON interface and
   W3C spec. Requires the use of WebDriver remote server.

--- a/test/async_window_test.dart
+++ b/test/async_window_test.dart
@@ -16,7 +16,6 @@
 library webdriver.window_test;
 
 import 'dart:async';
-import 'dart:math' show Point, Rectangle;
 
 import 'package:test/test.dart';
 import 'package:webdriver/async_core.dart';
@@ -34,7 +33,7 @@ void main() {
 
     test('size', () async {
       final window = await driver.window;
-      const size = Rectangle<int>(0, 0, 600, 400);
+      const size = Size(width: 600, height: 400);
 
       // Firefox may take a bit longer to do the resize.
       await Future.delayed(const Duration(seconds: 1));
@@ -44,7 +43,7 @@ void main() {
 
     test('location', () async {
       final window = await driver.window;
-      const position = Point<int>(100, 200);
+      const position = Position(x: 100, y: 200);
       await window.setLocation(position);
       expect(await window.location, position);
     });
@@ -52,8 +51,8 @@ void main() {
     // May not work on some OS/browser combinations (notably Mac OS X).
     test('maximize', () async {
       final window = await driver.window;
-      await window.setSize(const Rectangle<int>(0, 0, 300, 200));
-      await window.setLocation(const Point<int>(100, 200));
+      await window.setSize(const Size(width: 300, height: 200));
+      await window.setLocation(const Position(x: 100, y: 200));
       await window.maximize();
 
       // maximizing can take some time

--- a/test/configs/common_config.dart
+++ b/test/configs/common_config.dart
@@ -14,7 +14,6 @@
 
 import 'dart:async';
 import 'dart:io' show HttpServer, InternetAddress, Platform;
-import 'dart:math' show Point, Rectangle;
 
 import 'package:matcher/matcher.dart' show Matcher, TypeMatcher;
 import 'package:path/path.dart' as path;
@@ -25,8 +24,8 @@ final Uri _defaultFirefoxUri = Uri.parse('http://127.0.0.1:4445/');
 
 const WebDriverSpec defaultSpec = WebDriverSpec.JsonWire;
 
-const Matcher isRectangle = TypeMatcher<Rectangle<int>>();
-const Matcher isPoint = TypeMatcher<Point<int>>();
+const Matcher isRectangle = TypeMatcher<Rect>();
+const Matcher isPoint = TypeMatcher<Position>();
 
 Future<HttpServer> createLocalServer() =>
     HttpServer.bind(InternetAddress.anyIPv4, 0);

--- a/test/sync/window.dart
+++ b/test/sync/window.dart
@@ -16,7 +16,6 @@
 library webdriver.window_test;
 
 import 'dart:io';
-import 'dart:math' show Rectangle;
 
 import 'package:test/test.dart';
 import 'package:webdriver/sync_core.dart';
@@ -33,7 +32,7 @@ void runTests({WebDriverSpec spec = WebDriverSpec.Auto}) {
 
     test('size', () {
       final window = driver.window;
-      const windowRect = Rectangle<int>(0, 0, 600, 400);
+      const windowRect = Rect(left: 0, top: 0, width: 600, height: 400);
       window.rect = windowRect;
 
       // Firefox may take a bit longer to do the resize.
@@ -51,7 +50,7 @@ void runTests({WebDriverSpec spec = WebDriverSpec.Auto}) {
     // May not work on some OS/browser combinations (notably Mac OS X).
     test('maximize', () {
       final window = driver.window;
-      const windowRect = Rectangle<int>(100, 200, 300, 300);
+      const windowRect = Rect(left: 100, top: 200, width: 300, height: 300);
       window.rect = windowRect;
       window.maximize();
 


### PR DESCRIPTION
These types were built for `dart:html`, contain unrelated functionality, and require this library to always add an `int` generic. To aid the deprecation of these types in `dart:math`, migrate this package to custom types. These types, particularly the addition of a new `Size` type can more semantically match their purpose in the package, and be a bit simpler to use, no longer having a type parameter.

Contributes to https://github.com/dart-lang/sdk/issues/54852