### PR TITLE
Close HTTP clients if creating async session fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
+## 3.1.1-wip
+
+* Ensure HTTP clients are closed if creating a session fails.
+
 ## 3.1.0
 
 * Add a `reason` argument to `Clock.waitFor`.
-* Explicitly close http clients on quit. 
+* Explicitly close http clients on quit.
 
 ## 3.0.4
 

--- a/lib/async_core.dart
+++ b/lib/async_core.dart
@@ -18,6 +18,7 @@ import 'dart:collection' show UnmodifiableMapView;
 import 'src/async/web_driver.dart';
 import 'src/common/capabilities.dart';
 import 'src/common/request_client.dart';
+import 'src/common/session.dart';
 import 'src/common/spec.dart';
 import 'src/common/utils.dart';
 
@@ -43,10 +44,10 @@ export 'package:webdriver/src/common/spec.dart';
 
 final Uri defaultUri = Uri.parse('http://127.0.0.1:4444/wd/hub/');
 
-/// Creates a new async WebDriver.
+/// Creates a new async [WebDriver].
 ///
 /// This is intended for internal use! Please use [createDriver] from
-/// async_io.dart or async_html.dart.
+/// `async_io.dart` or `async_html.dart`.
 Future<WebDriver> createDriver(
     AsyncRequestClient Function(Uri prefix) createRequestClient,
     {Uri? uri,
@@ -59,10 +60,14 @@ Future<WebDriver> createDriver(
 
   final handler = getHandler(spec);
 
-  final session = await client.send(
-      handler.session.buildCreateRequest(desired: desired),
-      handler.session.parseCreateResponse);
-  client.close();
+  final SessionInfo session;
+  try {
+    session = await client.send(
+        handler.session.buildCreateRequest(desired: desired),
+        handler.session.parseCreateResponse);
+  } finally {
+    client.close();
+  }
 
   if (session.spec != WebDriverSpec.JsonWire &&
       session.spec != WebDriverSpec.W3c) {
@@ -73,10 +78,10 @@ Future<WebDriver> createDriver(
       createRequestClient(uri.resolve('session/${session.id}/')), session.spec);
 }
 
-/// Creates an async WebDriver from existing session.
+/// Creates an async [WebDriver] from existing session.
 ///
 /// This is intended for internal use! Please use [fromExistingSession] from
-/// async_io.dart or async_html.dart.
+/// `async_io.dart` or `async_html.dart`.
 Future<WebDriver> fromExistingSession(
     AsyncRequestClient Function(Uri prefix) createRequestClient,
     String sessionId,
@@ -89,9 +94,13 @@ Future<WebDriver> fromExistingSession(
 
   final handler = getHandler(spec);
 
-  final session = await client.send(handler.session.buildInfoRequest(sessionId),
-      (response) => handler.session.parseInfoResponse(response, sessionId));
-  client.close();
+  final SessionInfo session;
+  try {
+    session = await client.send(handler.session.buildInfoRequest(sessionId),
+        (response) => handler.session.parseInfoResponse(response, sessionId));
+  } finally {
+    client.close();
+  }
 
   if (session.spec != WebDriverSpec.JsonWire &&
       session.spec != WebDriverSpec.W3c) {
@@ -102,13 +111,13 @@ Future<WebDriver> fromExistingSession(
       createRequestClient(uri.resolve('session/${session.id}/')), session.spec);
 }
 
-/// Creates an async WebDriver from existing session with a sync function.
+/// Creates an async [WebDriver] from existing session with a sync function.
 ///
 /// This will be helpful when you can't use async when creating WebDriver. For
-/// example in a consctructor.
+/// example in a constructor.
 ///
 /// This is intended for internal use! Please use [fromExistingSessionSync] from
-/// async_io.dart or async_html.dart.
+/// `async_io.dart` or `async_html.dart`.
 WebDriver fromExistingSessionSync(
     AsyncRequestClient Function(Uri prefix) createRequestClient,
     String sessionId,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webdriver
-version: 3.1.0
+version: 3.1.1-wip
 description: >-
   Provides WebDriver bindings for Dart. Supports WebDriver JSON interface and
   W3C spec. Requires the use of WebDriver remote server.


### PR DESCRIPTION
As suggested by https://github.com/google/webdriver.dart/pull/311/files#r1933512660