### PR TITLE
chore: group dependabot github-actions updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,3 +7,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Configures Dependabot to bundle all GitHub Actions ecosystem
updates into a single pull request, reducing PR noise and
simplifying reviews.
